### PR TITLE
Fix leftover shell prompt in analysis script

### DIFF
--- a/simulateur_lora_sfrd_4.0/examples/analyse_resultats.py
+++ b/simulateur_lora_sfrd_4.0/examples/analyse_resultats.py
@@ -36,4 +36,3 @@ plt.title('Taux de livraison par nombre de nœuds')
 plt.tight_layout()
 plt.savefig('pdr_par_nodes.png')
 print("Graphique enregistré dans pdr_par_nodes.png")
-


### PR DESCRIPTION
## Summary
- clean up `examples/analyse_resultats.py` by removing an accidental shell prompt line

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68647de1a59883318c109faca7c7ec80