### PR TITLE
Add seed parameter for deterministic simulations

### DIFF
--- a/simulateur_lora_sfrd_4.0/README.md
+++ b/simulateur_lora_sfrd_4.0/README.md
@@ -30,6 +30,8 @@ panel serve launcher/dashboard.py --show
 python run.py --nodes 20 --steps 100
 ```
 
+Add `--seed <n>` to obtain the same node placement on each run.
+
 You can also execute the simulator directly from the repository root:
 
 ```bash

--- a/simulateur_lora_sfrd_4.0/VERSION_4/README.md
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/README.md
@@ -21,6 +21,8 @@ Bienvenue ! Ce projet est un **simulateur complet de réseau LoRa**, inspiré du
    python run.py --nodes 20 --mode Random --interval 15
    python run.py --nodes 5 --mode Periodic --interval 10
    ```
+   Ajoutez l'option `--seed` pour reproduire exactement le placement des nœuds
+   et passerelles.
 
 ## Exemples d'utilisation avancés
 

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/simulator.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/simulator.py
@@ -53,7 +53,8 @@ class Simulator:
                  fixed_sf: int | None = None,
                  fixed_tx_power: float | None = None,
                  battery_capacity_j: float | None = None,
-                 payload_size_bytes: int = 20):
+                 payload_size_bytes: int = 20,
+                 seed: int | None = None):
         """
         Initialise la simulation LoRa avec les entités et paramètres donnés.
         :param num_nodes: Nombre de nœuds à simuler.
@@ -78,6 +79,9 @@ class Simulator:
         :param fixed_tx_power: Si défini, puissance d'émission initiale commune (dBm).
         :param battery_capacity_j: Capacité de la batterie attribuée à chaque nœud (J). ``None`` pour illimité.
         :param payload_size_bytes: Taille du payload utilisé pour calculer l'airtime (octets).
+        :param seed: Graine aléatoire pour reproduire le placement des nœuds et
+            passerelles. ``None`` pour un tirage aléatoire différent à chaque
+            exécution.
         """
         # Paramètres de simulation
         self.num_nodes = num_nodes
@@ -112,6 +116,11 @@ class Simulator:
         # Compatibilité : premier canal par défaut
         self.channel = self.multichannel.channels[0]
         self.network_server = NetworkServer()
+
+        # Graine aléatoire facultative pour reproduire les résultats
+        self.seed = seed
+        if self.seed is not None:
+            random.seed(self.seed)
         
         # Générer les passerelles
         self.gateways = []

--- a/simulateur_lora_sfrd_4.0/VERSION_4/run.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/run.py
@@ -124,6 +124,11 @@ if __name__ == "__main__":
         action="store_true",
         help="Exécute un exemple LoRaWAN",
     )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        help="Graine aléatoire pour reproduire les résultats",
+    )
     args = parser.parse_args()
 
     logging.info(
@@ -131,6 +136,8 @@ if __name__ == "__main__":
         f"aire={args.area}m, {args.channels} canaux, mode={args.mode}, "
         f"intervalle={args.interval}, steps={args.steps}"
     )
+    if args.seed is not None:
+        random.seed(args.seed)
     if args.lorawan_demo:
         from launcher.node import Node
         from launcher.gateway import Gateway

--- a/simulateur_lora_sfrd_4.0/tests/test_simulator.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_simulator.py
@@ -214,3 +214,28 @@ def test_get_events_dataframe_has_all_columns():
     ]
     for col in expected_columns:
         assert col in df.columns
+
+
+def test_simulator_seed_reproducibility():
+    ch = Channel(shadowing_std=0)
+    kwargs = dict(
+        num_nodes=3,
+        num_gateways=2,
+        area_size=50.0,
+        transmission_mode="Random",
+        packet_interval=10.0,
+        packets_to_send=0,
+        mobility=False,
+        duty_cycle=None,
+        channels=[ch],
+        fixed_sf=7,
+        fixed_tx_power=14.0,
+    )
+    sim1 = Simulator(**kwargs, seed=42)
+    sim2 = Simulator(**kwargs, seed=42)
+    pos1 = [(n.x, n.y) for n in sim1.nodes]
+    pos2 = [(n.x, n.y) for n in sim2.nodes]
+    gw1 = [(g.x, g.y) for g in sim1.gateways]
+    gw2 = [(g.x, g.y) for g in sim2.gateways]
+    assert pos1 == pos2
+    assert gw1 == gw2


### PR DESCRIPTION
## Summary
- allow setting an optional random seed in `Simulator`
- propagate seed option to CLI script
- document `--seed` flag in both READMEs
- test reproducibility when the same seed is used

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6864816fe6848331b78fb6dba0996344