### PR TITLE
Fix requirements path in example script

### DIFF
--- a/simulateur_lora_sfrd_4.0/examples/analyse_resultats.py
+++ b/simulateur_lora_sfrd_4.0/examples/analyse_resultats.py
@@ -8,7 +8,7 @@ except ImportError as exc:  # pragma: no cover - optional dependencies
     missing = "pandas" if "pandas" in str(exc) else "matplotlib"
     print(
         f"Le module '{missing}' est requis pour exécuter ce script. "
-        "Installez les dépendances via 'pip install -r VERSION_3/requirements.txt'."
+        "Installez les dépendances via 'pip install -r VERSION_4/requirements.txt'."
     )
     raise SystemExit(1)
 


### PR DESCRIPTION
## Summary
- correct installation instructions in `analyse_resultats.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864867ba4a88331aad8863767d1219c