### PR TITLE
Fix bottom margin of simulation map

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/dashboard.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/dashboard.py
@@ -130,13 +130,14 @@ def update_map():
     )
     area = area_input.value
     # Add a small extra space on the Y axis so edge nodes remain fully visible
-    display_area_y = area * 1.125
+    extra_y = area * 0.125
+    display_area_y = area + extra_y
     fig.update_layout(
         title="Position des nœuds et passerelles",
         xaxis_title="X (m)",
         yaxis_title="Y (m)",
         xaxis_range=[0, area],
-        yaxis_range=[0, display_area_y],
+        yaxis_range=[-extra_y, display_area_y],
         yaxis=dict(scaleanchor="x", scaleratio=1),
         margin=dict(l=20, r=20, t=40, b=20),
     )


### PR DESCRIPTION
## Summary
- adjust dashboard map Y-axis to include margin below 0

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865a0f50c988331bc31771f3d69084f