### PR TITLE
Increase node marker size

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/dashboard.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/dashboard.py
@@ -112,7 +112,7 @@ def update_map():
         name="Nœuds",
         text=node_ids,
         textposition="middle center",
-        marker=dict(symbol="circle", color="blue", size=24),
+        marker=dict(symbol="circle", color="blue", size=32),
         textfont=dict(color="white", size=14),
     )
     x_gw = [gw.x for gw in sim.gateways]


### PR DESCRIPTION
## Summary
- bump dashboard node marker size to 32 for better visibility

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6865a2e4303083319a38ab277ad7d2fb