### PR TITLE
Fix README instruction

### DIFF
--- a/simulateur_lora_sfrd_4.0/README.md
+++ b/simulateur_lora_sfrd_4.0/README.md
@@ -26,6 +26,9 @@ pip install -r requirements.txt
 # Launch the dashboard
 panel serve launcher/dashboard.py --show
 
+# From the repository root use
+panel serve VERSION_4/launcher/dashboard.py --show
+
 The dashboard now exposes a **Graine** input. Set the same value on
 subsequent runs to keep the node placement identical.
 


### PR DESCRIPTION
## Summary
- clarify how to launch the dashboard when running from repo root

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6865a49740048331a749e4f687d6281b