### PR TITLE
Implement ADR profile selection via dashboard buttons

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/adr_2.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/adr_2.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from .simulator import Simulator
+
+
+def apply(sim: Simulator) -> None:
+    """Configure ADR variant adr_2."""
+    Simulator.MARGIN_DB = 30.0
+    sim.adr_node = True
+    sim.adr_server = True
+    sim.network_server.adr_enabled = True
+    for node in sim.nodes:
+        node.sf = 7
+        node.initial_sf = 7
+        node.tx_power = 14.0
+        node.initial_tx_power = 14.0
+        node.adr_ack_cnt = 0
+        node.adr_ack_limit = 8
+        node.adr_ack_delay = 4

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/adr_3.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/adr_3.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from .simulator import Simulator
+
+
+def apply(sim: Simulator) -> None:
+    """Configure ADR variant adr_3."""
+    Simulator.MARGIN_DB = 25.0
+    sim.adr_node = True
+    sim.adr_server = True
+    sim.network_server.adr_enabled = True
+    for node in sim.nodes:
+        node.sf = 9
+        node.initial_sf = 9
+        node.tx_power = 14.0
+        node.initial_tx_power = 14.0
+        node.adr_ack_cnt = 0
+        node.adr_ack_limit = 16
+        node.adr_ack_delay = 12

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/adr_standard_1.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/adr_standard_1.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from .simulator import Simulator
+
+
+def apply(sim: Simulator) -> None:
+    """Configure ADR variant adr_standard_1 (LoRaWAN defaults)."""
+    Simulator.MARGIN_DB = 15.0
+    sim.adr_node = True
+    sim.adr_server = True
+    sim.network_server.adr_enabled = True
+    for node in sim.nodes:
+        node.sf = 12
+        node.initial_sf = 12
+        node.tx_power = 14.0
+        node.initial_tx_power = 14.0
+        node.adr_ack_cnt = 0
+        node.adr_ack_limit = 64
+        node.adr_ack_delay = 32


### PR DESCRIPTION
## Summary
- add modules `adr_standard_1`, `adr_2`, `adr_3` providing separate ADR configurations
- expose buttons on the dashboard to choose an ADR variant and highlight the active one
- automatically apply the selected profile when starting the simulation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686841b004d08331b7052d81cacb2be3