### PR TITLE
Add throughput metrics and test

### DIFF
--- a/simulateur_lora_sfrd_4.0/README.md
+++ b/simulateur_lora_sfrd_4.0/README.md
@@ -30,7 +30,7 @@ panel serve launcher/dashboard.py --show
 # From the repository root use
 panel serve VERSION_4/launcher/dashboard.py --show
 
-The dashboard now exposes a **Graine** input. Set the same value on
+The dashboard now exposes a **Seed** input. Set the same value on
 subsequent runs to keep the node placement identical.
 
 # Run a simulation

--- a/simulateur_lora_sfrd_4.0/VERSION_4/run.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/run.py
@@ -4,6 +4,8 @@ import random
 import logging
 import sys
 
+PAYLOAD_SIZE = 20  # octets simulés par paquet
+
 # Configuration du logger pour afficher les informations
 logging.basicConfig(level=logging.INFO, format="%(message)s")
 
@@ -76,8 +78,16 @@ def simulate(nodes, gateways, area, mode, interval, steps, channels=1):
         else 0
     )
     avg_delay = (sum(delays) / len(delays)) if delays else 0
+    throughput_bps = delivered * PAYLOAD_SIZE * 8 / steps if steps > 0 else 0.0
 
-    return delivered, collisions, pdr, energy_consumed, avg_delay
+    return (
+        delivered,
+        collisions,
+        pdr,
+        energy_consumed,
+        avg_delay,
+        throughput_bps,
+    )
 
 
 if __name__ == "__main__":
@@ -157,7 +167,7 @@ if __name__ == "__main__":
         )
         sys.exit()
 
-    delivered, collisions, pdr, energy, avg_delay = simulate(
+    delivered, collisions, pdr, energy, avg_delay, throughput = simulate(
         args.nodes,
         args.gateways,
         args.area,
@@ -168,7 +178,8 @@ if __name__ == "__main__":
     )
     logging.info(
         f"Résultats : PDR={pdr:.2f}% , Paquets livrés={delivered}, Collisions={collisions}, "
-        f"Énergie consommée={energy:.1f} unités, Délai moyen={avg_delay:.2f} unités de temps"
+        f"Énergie consommée={energy:.1f} unités, Délai moyen={avg_delay:.2f} unités de temps, "
+        f"Débit moyen={throughput:.2f} bps"
     )
 
     # Sauvegarde des résultats dans un CSV si demandé
@@ -190,6 +201,7 @@ if __name__ == "__main__":
                     "PDR(%)",
                     "energy",
                     "avg_delay",
+                    "throughput_bps",
                 ]
             )
             # Données
@@ -207,6 +219,7 @@ if __name__ == "__main__":
                     f"{pdr:.2f}",
                     f"{energy:.1f}",
                     f"{avg_delay:.2f}",
+                    f"{throughput:.2f}",
                 ]
             )
         logging.info(f"Résultats enregistrés dans {args.output}")

--- a/simulateur_lora_sfrd_4.0/tests/test_run_script.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_run_script.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+
+# Allow importing the VERSION_4 package from the repository root
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import VERSION_4.run as run
+
+
+def test_simulate_throughput_bps():
+    delivered, collisions, pdr, energy, avg_delay, throughput = run.simulate(
+        nodes=1,
+        gateways=1,
+        area=10,
+        mode="Periodic",
+        interval=1,
+        steps=10,
+        channels=1,
+    )
+    assert delivered == 10
+    expected_throughput = delivered * run.PAYLOAD_SIZE * 8 / 10
+    assert throughput == expected_throughput


### PR DESCRIPTION
## Summary
- fix typo in README
- compute `throughput_bps` in `run.py` and output it in CSV
- log the throughput metric
- test throughput calculation via `simulate`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868437174cc833180a40cb27c547ee8