### PR TITLE
Remove unused area parameter

### DIFF
--- a/simulateur_lora_sfrd_4.0/README.md
+++ b/simulateur_lora_sfrd_4.0/README.md
@@ -53,7 +53,7 @@ Here are some commands to explore more simulator features:
 
 ```bash
 # Multi-channel simulation with node mobility
-python VERSION_4/run.py --nodes 50 --gateways 2 --area 2000 --channels 3 \
+python VERSION_4/run.py --nodes 50 --gateways 2 --channels 3 \
   --mobility --steps 500 --output advanced.csv
 
 # LoRaWAN demo with downlinks

--- a/simulateur_lora_sfrd_4.0/VERSION_4/README.md
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/README.md
@@ -19,7 +19,7 @@ Définissez la valeur du champ **Graine** pour réutiliser le même placement de
 nœuds d'une simulation à l'autre.
 4. **Exécutez des simulations en ligne de commande :**
    ```bash
-   python run.py --nodes 30 --gateways 1 --area 1000 --mode Random --interval 10 --steps 100 --output resultats.csv
+   python run.py --nodes 30 --gateways 1 --mode Random --interval 10 --steps 100 --output resultats.csv
    python run.py --nodes 20 --mode Random --interval 15
    python run.py --nodes 5 --mode Periodic --interval 10
    ```
@@ -32,7 +32,7 @@ Quelques commandes pour tester des scénarios plus complexes :
 
 ```bash
 # Simulation multi-canaux avec mobilité
-python run.py --nodes 50 --gateways 2 --area 2000 --channels 3 \
+python run.py --nodes 50 --gateways 2 --channels 3 \
   --mobility --steps 500 --output advanced.csv
 
 # Démonstration LoRaWAN avec downlinks

--- a/simulateur_lora_sfrd_4.0/VERSION_4/run.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/run.py
@@ -10,7 +10,7 @@ PAYLOAD_SIZE = 20  # octets simulés par paquet
 logging.basicConfig(level=logging.INFO, format="%(message)s")
 
 
-def simulate(nodes, gateways, area, mode, interval, steps, channels=1):
+def simulate(nodes, gateways, mode, interval, steps, channels=1):
     """Exécute une simulation LoRa simplifiée et retourne les métriques.
 
     Les transmissions peuvent se faire sur plusieurs canaux et plusieurs
@@ -99,12 +99,6 @@ if __name__ == "__main__":
         "--gateways", type=int, default=1, help="Nombre de gateways"
     )
     parser.add_argument(
-        "--area",
-        type=int,
-        default=1000,
-        help="Taille de l'aire de simulation (côté du carré)",
-    )
-    parser.add_argument(
         "--channels", type=int, default=1, help="Nombre de canaux radio"
     )
     parser.add_argument(
@@ -144,7 +138,7 @@ if __name__ == "__main__":
 
     logging.info(
         f"Simulation d'un réseau LoRa : {args.nodes} nœuds, {args.gateways} gateways, "
-        f"aire={args.area}m, {args.channels} canaux, mode={args.mode}, "
+        f"{args.channels} canaux, mode={args.mode}, "
         f"intervalle={args.interval}, steps={args.steps}"
     )
     if args.seed is not None:
@@ -170,7 +164,6 @@ if __name__ == "__main__":
     delivered, collisions, pdr, energy, avg_delay, throughput = simulate(
         args.nodes,
         args.gateways,
-        args.area,
         args.mode,
         args.interval,
         args.steps,
@@ -191,7 +184,6 @@ if __name__ == "__main__":
                 [
                     "nodes",
                     "gateways",
-                    "area",
                     "channels",
                     "mode",
                     "interval",
@@ -209,7 +201,6 @@ if __name__ == "__main__":
                 [
                     args.nodes,
                     args.gateways,
-                    args.area,
                     args.channels,
                     args.mode,
                     args.interval,

--- a/simulateur_lora_sfrd_4.0/tests/test_run_script.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_run_script.py
@@ -12,7 +12,6 @@ def test_simulate_throughput_bps():
     delivered, collisions, pdr, energy, avg_delay, throughput = run.simulate(
         nodes=1,
         gateways=1,
-        area=10,
         mode="Periodic",
         interval=1,
         steps=10,


### PR DESCRIPTION
## Summary
- drop unused `area` parameter from command-line interface
- update related docs and examples
- adjust test accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868495044248331bc35101afea797fd