### PR TITLE
Fix battery level bug and update docs

### DIFF
--- a/simulateur_lora_sfrd_4.0/README.md
+++ b/simulateur_lora_sfrd_4.0/README.md
@@ -60,7 +60,7 @@ python VERSION_4/run.py --nodes 50 --gateways 2 --channels 3 \
 python VERSION_4/run.py --lorawan-demo --steps 100 --output lorawan.csv
 ```
 
-You can analyse the resulting CSV file with:
+You can analyze the resulting CSV file with:
 
 ```bash
 python examples/analyse_resultats.py advanced.csv

--- a/simulateur_lora_sfrd_4.0/VERSION_4/README.md
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/README.md
@@ -135,12 +135,11 @@ L'option `--output` de `run.py` permet d'enregistrer les métriques de la
 simulation dans un fichier CSV. Ce dernier contient l'en‑tête suivant :
 
 ```
-nodes,gateways,area,channels,mode,interval,steps,delivered,collisions,PDR(%),energy,avg_delay,throughput_bps
+nodes,gateways,channels,mode,interval,steps,delivered,collisions,PDR(%),energy,avg_delay,throughput_bps
 ```
 
 * **nodes** : nombre de nœuds simulés.
 * **gateways** : nombre de passerelles.
-* **area** : côté du carré de simulation en mètres.
 * **channels** : nombre de canaux radio simulés.
 * **mode** : `Random` ou `Periodic`.
 * **interval** : intervalle moyen/fixe entre deux transmissions.

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/node.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/node.py
@@ -129,6 +129,8 @@ class Node:
         """Return the remaining battery level as a ratio between 0 and 1."""
         if self.battery_capacity_j == float('inf'):
             return 1.0
+        if self.battery_capacity_j == 0:
+            return 0.0
         return max(0.0, self.battery_remaining_j / self.battery_capacity_j)
 
     def distance_to(self, other) -> float:

--- a/simulateur_lora_sfrd_4.0/tests/test_battery.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_battery.py
@@ -1,0 +1,14 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from VERSION_4.launcher.node import Node  # noqa: E402
+from VERSION_4.launcher.channel import Channel  # noqa: E402
+
+
+def test_battery_level_zero_capacity():
+    node = Node(1, 0.0, 0.0, 7, 14.0, channel=Channel(), battery_capacity_j=0)
+    assert node.battery_level == 0.0
+


### PR DESCRIPTION
## Summary
- harmonize README wording using "analyze"
- update CSV header in VERSION_4 docs
- avoid division by zero in `Node.battery_level`
- add regression test for zero battery capacity

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868c78d5dbc8331a0bbd8a075564de8