### PR TITLE
Fix interval check in run.simulate

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/run.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/run.py
@@ -24,6 +24,8 @@ def simulate(nodes, gateways, mode, interval, steps, channels=1):
         raise ValueError("gateways must be >= 1")
     if channels < 1:
         raise ValueError("channels must be >= 1")
+    if interval <= 0:
+        raise ValueError("interval must be > 0")
 
     # Initialisation des compteurs
     total_transmissions = 0


### PR DESCRIPTION
## Summary
- guard against zero or negative interval in `simulate`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68744abe7a8083319e4013fa9b70e8d9