### PR TITLE
Fix Node.consume_until docstring

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/node.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/node.py
@@ -231,7 +231,7 @@ class Node:
                 self.alive = False
 
     def consume_until(self, current_time: float) -> None:
-        """Accumulates energy from ``last_state_time`` up to ``current_time``."""
+        """Accumulate energy from ``last_state_time`` to ``current_time``."""
         dt = current_time - self.last_state_time
         if dt <= 0:
             self.last_state_time = current_time


### PR DESCRIPTION
## Summary
- correct docstring wording in `Node.consume_until`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68744ac6c0608331a58227276a3a27f2