### PR TITLE
Fix package import by adding __init__

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/__init__.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/__init__.py
@@ -1,0 +1,1 @@
+# Init for versioned package


### PR DESCRIPTION
## Summary
- add missing `__init__.py` file so VERSION_4 can be imported when installed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68758859d140833194598d69bba20bf9