### PR TITLE
Add multiple run support to CLI

### DIFF
--- a/simulateur_lora_sfrd_4.0/README.md
+++ b/simulateur_lora_sfrd_4.0/README.md
@@ -40,6 +40,7 @@ python run.py --nodes 20 --steps 100
 ```
 
 Add `--seed <n>` to obtain the same node placement on each run.
+Use `--runs <n>` to repeat the simulation several times and average the metrics.
 
 You can also execute the simulator directly from the repository root:
 

--- a/simulateur_lora_sfrd_4.0/VERSION_4/README.md
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/README.md
@@ -23,8 +23,10 @@ nœuds d'une simulation à l'autre.
    python run.py --nodes 20 --mode Random --interval 15
    python run.py --nodes 5 --mode Periodic --interval 10
    ```
-   Ajoutez l'option `--seed` pour reproduire exactement le placement des nœuds
-   et passerelles.
+    Ajoutez l'option `--seed` pour reproduire exactement le placement des nœuds
+    et passerelles.
+    Utilisez `--runs <n>` pour exécuter plusieurs simulations d'affilée et
+    obtenir une moyenne des métriques.
 
 ## Exemples d'utilisation avancés
 

--- a/simulateur_lora_sfrd_4.0/tests/test_run_script.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_run_script.py
@@ -20,3 +20,18 @@ def test_simulate_throughput_bps():
     assert delivered == 10
     expected_throughput = delivered * run.PAYLOAD_SIZE * 8 / 10
     assert throughput == expected_throughput
+
+
+def test_main_runs_multiple_times(monkeypatch):
+    calls = []
+
+    def fake_simulate(*args, **kwargs):
+        calls.append(1)
+        return (1, 2, 3, 4, 5, 6)
+
+    monkeypatch.setattr(run, "simulate", fake_simulate)
+    results, avg = run.main(["--runs", "3"])
+
+    assert len(calls) == 3
+    assert results == [(1, 2, 3, 4, 5, 6)] * 3
+    assert avg == (1.0, 2.0, 3.0, 4.0, 5.0, 6.0)


### PR DESCRIPTION
## Summary
- allow repeating simulations with `--runs`
- loop simulate calls and average metrics
- record each run in CSV output
- test multiple run behaviour
- document new option in READMEs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876f94d1d1483319d6fa6ed9cc50a74