### PR TITLE
Add script to analyze run metrics

### DIFF
--- a/simulateur_lora_sfrd_4.0/README.md
+++ b/simulateur_lora_sfrd_4.0/README.md
@@ -68,6 +68,14 @@ You can analyze the resulting CSV file with:
 python examples/analyse_resultats.py advanced.csv
 ```
 
+If you collected several runs into one CSV via the dashboard or
+`python VERSION_4/run.py --runs <n> --output results.csv`, use
+`analyse_runs.py` to compute the average metrics for each run:
+
+```bash
+python examples/analyse_runs.py results.csv
+```
+
 ## Validating results
 
 Run the test suite to ensure everything works as expected:

--- a/simulateur_lora_sfrd_4.0/VERSION_4/README.md
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/README.md
@@ -164,6 +164,14 @@ python examples/analyse_resultats.py resultats1.csv resultats2.csv
 Le script affiche le PDR moyen puis sauvegarde un graphique dans
 `pdr_par_nodes.png`.
 
+Si le même fichier CSV contient plusieurs runs produits avec le dashboard ou
+`run.py --runs`, le script `analyse_runs.py` permet d'obtenir les moyennes par
+run :
+
+```bash
+python examples/analyse_runs.py resultats.csv
+```
+
 ## Validation des résultats
 
 L'exécution de `pytest` permet de vérifier la cohérence des calculs de RSSI et le traitement des collisions :

--- a/simulateur_lora_sfrd_4.0/examples/analyse_runs.py
+++ b/simulateur_lora_sfrd_4.0/examples/analyse_runs.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Analyse les résultats de plusieurs runs enregistrés dans un seul CSV."""
+import sys
+
+try:
+    import pandas as pd
+    import matplotlib.pyplot as plt
+except ImportError as exc:  # pragma: no cover - optional deps
+    missing = "pandas" if "pandas" in str(exc) else "matplotlib"
+    print(
+        f"Le module '{missing}' est requis pour exécuter ce script. "
+        "Installez les dépendances via 'pip install -r VERSION_4/requirements.txt'."
+    )
+    raise SystemExit(1)
+
+if len(sys.argv) != 2:
+    print("Usage: python analyse_runs.py resultats.csv")
+    sys.exit(1)
+
+csv_path = sys.argv[1]
+
+df = pd.read_csv(csv_path)
+
+# Conversion des colonnes numériques courantes
+for col in ["PDR(%)", "collisions", "avg_delay", "avg_delay_s", "throughput_bps", "energy", "energy_J"]:
+    if col in df.columns:
+        df[col] = pd.to_numeric(df[col], errors="coerce")
+
+energy_col = "energy_J" if "energy_J" in df.columns else "energy" if "energy" in df.columns else None
+
+# Agrégation par numéro de run
+if "run" not in df.columns:
+    print("La colonne 'run' est absente du CSV.")
+    sys.exit(1)
+
+metrics = ["PDR(%)", "collisions", "avg_delay", "avg_delay_s", "throughput_bps"]
+if energy_col:
+    metrics.append(energy_col)
+
+avg = df.groupby("run")[metrics].mean()
+print(avg)
+
+if "PDR(%)" in avg.columns:
+    plt.figure()
+    avg["PDR(%)"].plot(kind="bar")
+    plt.ylabel("PDR (%)")
+    plt.title("PDR moyen par run")
+    plt.tight_layout()
+    plt.savefig("pdr_par_run.png")
+    print("Graphique enregistré dans pdr_par_run.png")


### PR DESCRIPTION
## Summary
- add `examples/analyse_runs.py` to compute averages per run
- document the new script in README and VERSION_4/README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876f9589ed4833187e4410a9037b318