### PR TITLE
Fix CLI runs check and improve docs/tests

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/README.md
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/README.md
@@ -21,7 +21,7 @@ d'enchaîner automatiquement plusieurs simulations identiques (la graine est
 incrémentée à chaque run).
 4. **Exécutez des simulations en ligne de commande :**
    ```bash
-   python run.py --nodes 30 --gateways 1 --mode Random --interval 10 --steps 100 --output resultats.csv
+   python run.py --nodes 30 --gateways 1 --mode Random --interval 10 --steps 100 --output résultats.csv
    python run.py --nodes 20 --mode Random --interval 15
    python run.py --nodes 5 --mode Periodic --interval 10
    ```
@@ -173,7 +173,7 @@ Si le même fichier CSV contient plusieurs runs produits avec le dashboard ou
 run :
 
 ```bash
-python examples/analyse_runs.py resultats.csv
+python examples/analyse_runs.py résultats.csv
 ```
 
 ## Validation des résultats

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/clean_results.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/clean_results.py
@@ -53,7 +53,11 @@ def main() -> None:
     args = parser.parse_args()
 
     cleaned = clean_csv(args.csv_file, args.output)
-    print(f"Fichier nettoyé enregistré dans {cleaned}")
+    if args.output is None:
+        default_path = os.path.splitext(args.csv_file)[0] + "_clean.csv"
+        print(f"Fichier nettoyé enregistré dans {default_path}")
+    else:
+        print(f"Fichier nettoyé enregistré dans {cleaned}")
 
 
 if __name__ == "__main__":

--- a/simulateur_lora_sfrd_4.0/VERSION_4/run.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/run.py
@@ -144,6 +144,9 @@ def main(argv=None):
     )
     args = parser.parse_args(argv)
 
+    if args.runs < 1:
+        parser.error("--runs must be >= 1")
+
     logging.info(
         f"Simulation d'un réseau LoRa : {args.nodes} nœuds, {args.gateways} gateways, "
         f"{args.channels} canaux, mode={args.mode}, "

--- a/simulateur_lora_sfrd_4.0/tests/test_run_script.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_run_script.py
@@ -1,5 +1,6 @@
 import sys
 from pathlib import Path
+import pytest
 
 # Allow importing the VERSION_4 package from the repository root
 ROOT = Path(__file__).resolve().parents[1]
@@ -35,3 +36,25 @@ def test_main_runs_multiple_times(monkeypatch):
     assert len(calls) == 3
     assert results == [(1, 2, 3, 4, 5, 6)] * 3
     assert avg == (1.0, 2.0, 3.0, 4.0, 5.0, 6.0)
+
+
+def test_simulate_invalid_arguments():
+    with pytest.raises(ValueError):
+        run.simulate(
+            nodes=0,
+            gateways=1,
+            mode="Periodic",
+            interval=1,
+            steps=10,
+            channels=1,
+        )
+
+    with pytest.raises(ValueError):
+        run.simulate(
+            nodes=1,
+            gateways=1,
+            mode="Periodic",
+            interval=1,
+            steps=10,
+            channels=0,
+        )


### PR DESCRIPTION
## Summary
- fix a typo in README with `résultats.csv`
- validate `--runs` option is >= 1
- clarify cleaned CSV message
- test invalid arguments to `simulate`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687706505bdc8331bf326e4b1c672b0d