### PR TITLE
Fix fast_forward curdoc usage

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/dashboard.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/dashboard.py
@@ -471,6 +471,7 @@ export_button.on_click(exporter_csv)
 # --- Bouton d'accélération ---
 def fast_forward(event=None):
     global sim, sim_callback, chrono_callback, start_time, max_real_time
+    doc = pn.state.curdoc
     if sim and sim.running:
         if sim.packets_to_send == 0:
             export_message.object = (
@@ -519,7 +520,7 @@ def fast_forward(event=None):
                 update_map()
                 on_stop(None)
 
-            pn.state.curdoc.add_next_tick_callback(update_ui)
+            doc.add_next_tick_callback(update_ui)
 
         threading.Thread(target=run_and_update, daemon=True).start()
 


### PR DESCRIPTION
## Summary
- capture Panel's curdoc in fast_forward
- reference the stored document when scheduling UI updates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878ddf012d88331a670b3953447acb4