### PR TITLE
Add steps validation

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/run.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/run.py
@@ -26,6 +26,8 @@ def simulate(nodes, gateways, mode, interval, steps, channels=1):
         raise ValueError("channels must be >= 1")
     if interval <= 0:
         raise ValueError("interval must be > 0")
+    if steps <= 0:
+        raise ValueError("steps must be > 0")
 
     # Initialisation des compteurs
     total_transmissions = 0

--- a/simulateur_lora_sfrd_4.0/tests/test_run_script.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_run_script.py
@@ -58,3 +58,24 @@ def test_simulate_invalid_arguments():
             steps=10,
             channels=0,
         )
+
+    # Ensure invalid steps values raise errors
+    with pytest.raises(ValueError):
+        run.simulate(
+            nodes=1,
+            gateways=1,
+            mode="Periodic",
+            interval=1,
+            steps=0,
+            channels=1,
+        )
+
+    with pytest.raises(ValueError):
+        run.simulate(
+            nodes=1,
+            gateways=1,
+            mode="Periodic",
+            interval=1,
+            steps=-5,
+            channels=1,
+        )


### PR DESCRIPTION
## Summary
- error check to prevent `simulate` from running with 0 or negative steps
- validate incorrect `steps` in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878e905c0fc8331b07a18375296ac72