### PR TITLE
Add detection threshold option

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/README.md
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/README.md
@@ -103,6 +103,8 @@ Depuis cette mise à jour, la largeur de bande (`bandwidth`) et le codage
 (`coding_rate`) sont également configurables lors de la création d'un
 `Channel`. On peut modéliser des interférences externes via `interference_dB`
 et introduire des variations aléatoires de puissance avec `tx_power_std`.
+Un seuil de détection peut être fixé via `detection_threshold_dBm` (par
+exemple `-110` dBm comme dans FLoRa) pour ignorer les signaux trop faibles.
 
 ## SF et puissance initiaux
 

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/channel.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/channel.py
@@ -20,6 +20,7 @@ class Channel:
         capture_threshold_dB: float = 6.0,
         tx_power_std: float = 0.0,
         interference_dB: float = 0.0,
+        detection_threshold_dBm: float = -float("inf"),
     ):
         """
         Initialise le canal radio avec paramètres de propagation.
@@ -38,6 +39,8 @@ class Channel:
         :param capture_threshold_dB: Seuil de capture pour le décodage simultané.
         :param tx_power_std: Écart-type de la variation aléatoire de puissance TX.
         :param interference_dB: Bruit supplémentaire moyen dû aux interférences.
+        :param detection_threshold_dBm: RSSI minimal détectable (dBm). Les
+            signaux plus faibles sont ignorés.
         """
 
         self.frequency_hz = frequency_hz
@@ -50,6 +53,7 @@ class Channel:
         self.noise_floor_std = noise_floor_std
         self.tx_power_std = tx_power_std
         self.interference_dB = interference_dB
+        self.detection_threshold_dBm = detection_threshold_dBm
 
         # Paramètres LoRa (BW 125 kHz, CR 4/5, préambule 8, CRC activé)
         self.bandwidth = bandwidth


### PR DESCRIPTION
## Summary
- add `detection_threshold_dBm` parameter to Channel
- expose threshold through Simulator and use it during RX
- mention new option in README
- skip downlinks below threshold in tests
- add unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878eadd6d548331b1f936dfbcf31199