### PR TITLE
Add minimal interference time support

### DIFF
--- a/simulateur_lora_sfrd_4.0/README.md
+++ b/simulateur_lora_sfrd_4.0/README.md
@@ -8,6 +8,7 @@ This repository contains a lightweight LoRa network simulator implemented in Pyt
 - Multi-channel radio support
 - Advanced channel model with loss and noise parameters
 - Configurable bandwidth and coding rate per channel
+- Capture effect and a minimum interference time to ignore very short overlaps
 - Initial spreading factor and power selection
 - Full LoRaWAN ADR layer following the official specification (LinkADRReq/Ans,
   ADRACKReq, channel mask, NbTrans, ADR_ACK_DELAY fallback) and derived from the

--- a/simulateur_lora_sfrd_4.0/VERSION_4/README.md
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/README.md
@@ -105,6 +105,9 @@ Depuis cette mise à jour, la largeur de bande (`bandwidth`) et le codage
 et introduire des variations aléatoires de puissance avec `tx_power_std`.
 Un seuil de détection peut être fixé via `detection_threshold_dBm` (par
 exemple `-110` dBm comme dans FLoRa) pour ignorer les signaux trop faibles.
+Le paramètre `min_interference_time` de `Simulator` permet de définir une durée
+de chevauchement sous laquelle deux paquets ne sont pas considérés comme en
+collision.
 
 ## SF et puissance initiaux
 

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/simulator.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/simulator.py
@@ -55,6 +55,7 @@ class Simulator:
                  battery_capacity_j: float | None = None,
                  payload_size_bytes: int = 20,
                  detection_threshold_dBm: float = -float("inf"),
+                 min_interference_time: float = 0.0,
                  seed: int | None = None):
         """
         Initialise la simulation LoRa avec les entités et paramètres donnés.
@@ -82,6 +83,8 @@ class Simulator:
         :param payload_size_bytes: Taille du payload utilisé pour calculer l'airtime (octets).
         :param detection_threshold_dBm: RSSI minimal requis pour qu'une
             réception soit prise en compte.
+        :param min_interference_time: Chevauchement temporel toléré entre
+            transmissions avant de les considérer en collision (s).
         :param seed: Graine aléatoire pour reproduire le placement des nœuds et
             passerelles. ``None`` pour un tirage aléatoire différent à chaque
             exécution.
@@ -100,6 +103,7 @@ class Simulator:
         self.battery_capacity_j = battery_capacity_j
         self.payload_size_bytes = payload_size_bytes
         self.detection_threshold_dBm = detection_threshold_dBm
+        self.min_interference_time = min_interference_time
         # Activation ou non de la mobilité des nœuds
         self.mobility_enabled = mobility
         self.mobility_model = SmoothMobility(area_size, mobility_speed[0], mobility_speed[1])
@@ -335,6 +339,7 @@ class Simulator:
                     node.channel.capture_threshold_dB,
                     self.current_time,
                     node.channel.frequency_hz,
+                    self.min_interference_time,
                 )
             
             # Retenir le meilleur RSSI/SNR mesuré pour cette transmission


### PR DESCRIPTION
## Summary
- handle minimum interference duration in Gateway
- expose `min_interference_time` in Simulator and pass it to gateways
- document the new parameter in READMEs
- add a test showing that short overlaps no longer collide

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878eda97a44833190078945618f5927