### PR TITLE
Fix output message in CSV cleaner

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/clean_results.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/clean_results.py
@@ -53,11 +53,7 @@ def main() -> None:
     args = parser.parse_args()
 
     cleaned = clean_csv(args.csv_file, args.output)
-    if args.output is None:
-        default_path = os.path.splitext(args.csv_file)[0] + "_clean.csv"
-        print(f"Fichier nettoyé enregistré dans {default_path}")
-    else:
-        print(f"Fichier nettoyé enregistré dans {cleaned}")
+    print(f"Fichier nettoyé enregistré dans {cleaned}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- remove redundant path handling when printing cleaned CSV path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6878ef9695748331bb9012049d7cc107