### PR TITLE
Fix ADR1 algorithm by disabling node side logic

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/adr_standard_1.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/adr_standard_1.py
@@ -6,7 +6,7 @@ from .simulator import Simulator
 def apply(sim: Simulator) -> None:
     """Configure ADR variant adr_standard_1 (LoRaWAN defaults)."""
     Simulator.MARGIN_DB = 15.0
-    sim.adr_node = True
+    sim.adr_node = False
     sim.adr_server = True
     sim.network_server.adr_enabled = True
     for node in sim.nodes:


### PR DESCRIPTION
## Summary
- disable node driven ADR logic for ADR standard 1

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687900db16c883318a76773e216d16ca