### PR TITLE
Add TX power mapping for energy

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/energy_profiles.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/energy_profiles.py
@@ -1,5 +1,15 @@
 from dataclasses import dataclass
 
+DEFAULT_TX_CURRENT_MAP_A: dict[float, float] = {
+    2.0: 0.02,  # ~20 mA
+    5.0: 0.027,  # ~27 mA
+    8.0: 0.035,  # ~35 mA
+    11.0: 0.045,  # ~45 mA
+    14.0: 0.060,  # ~60 mA
+    17.0: 0.10,  # ~100 mA
+    20.0: 0.12,  # ~120 mA
+}
+
 @dataclass(frozen=True)
 class EnergyProfile:
     """Energy consumption parameters for a LoRa node."""
@@ -8,7 +18,15 @@ class EnergyProfile:
     rx_current_a: float = 11e-3
     process_current_a: float = 5e-3
     rx_window_duration: float = 0.1
+    tx_current_map_a: dict[float, float] | None = None
+
+    def get_tx_current(self, power_dBm: float) -> float:
+        """Return TX current for the closest power value in the mapping."""
+        if not self.tx_current_map_a:
+            return 0.0
+        key = min(self.tx_current_map_a.keys(), key=lambda k: abs(k - power_dBm))
+        return self.tx_current_map_a[key]
 
 
 # Default profile based on the FLoRa model (OMNeT++)
-FLORA_PROFILE = EnergyProfile()
+FLORA_PROFILE = EnergyProfile(tx_current_map_a=DEFAULT_TX_CURRENT_MAP_A)

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/simulator.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/simulator.py
@@ -296,9 +296,9 @@ class Simulator:
             # Mettre à jour les compteurs de paquets émis
             self.packets_sent += 1
             node.increment_sent()
-            # Énergie consommée par la transmission (E = P(mW) * t)
-            p_mW = 10 ** (tx_power / 10.0)  # convertir dBm en mW
-            energy_J = (p_mW / 1000.0) * duration
+            # Énergie consommée par la transmission (E = I * V * t)
+            current_a = node.profile.get_tx_current(tx_power)
+            energy_J = current_a * node.profile.voltage_v * duration
             self.total_energy_J += energy_J
             node.add_energy(energy_J, "tx")
             if not node.alive:

--- a/simulateur_lora_sfrd_4.0/tests/test_battery.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_battery.py
@@ -4,8 +4,11 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
+import pytest
+
 from VERSION_4.launcher.node import Node  # noqa: E402
 from VERSION_4.launcher.channel import Channel  # noqa: E402
+from VERSION_4.launcher.simulator import Simulator  # noqa: E402
 
 
 def test_battery_level_zero_capacity():
@@ -19,4 +22,43 @@ def test_battery_consumption_decreases_level():
     node.add_energy(1.5, state="tx")
     assert node.battery_remaining_j == 8.5
     assert round(node.battery_level, 2) == 0.85
+
+
+def _consumption_for_power(tx_power: float):
+    ch = Channel(shadowing_std=0)
+    sim = Simulator(
+        num_nodes=1,
+        num_gateways=1,
+        area_size=10.0,
+        transmission_mode="Periodic",
+        packet_interval=10.0,
+        packets_to_send=1,
+        mobility=False,
+        duty_cycle=None,
+        channels=[ch],
+        fixed_sf=7,
+        fixed_tx_power=tx_power,
+        battery_capacity_j=10.0,
+    )
+    node = sim.nodes[0]
+    gw = sim.gateways[0]
+    node.x = gw.x
+    node.y = gw.y
+    sim.event_queue.clear()
+    sim.event_id_counter = 0
+    sim.schedule_event(node, 0.0)
+    sim.run()
+    consumed = 10.0 - node.battery_remaining_j
+    duration = node.channel.airtime(7, payload_size=sim.payload_size_bytes)
+    profile = node.profile
+    expected = profile.get_tx_current(tx_power) * profile.voltage_v * duration
+    return consumed, expected
+
+
+def test_tx_power_mapping_affects_consumption():
+    low, expected_low = _consumption_for_power(2.0)
+    high, expected_high = _consumption_for_power(14.0)
+    assert high > low
+    assert low == pytest.approx(expected_low, rel=1e-3)
+    assert high == pytest.approx(expected_high, rel=1e-3)
 


### PR DESCRIPTION
## Summary
- add TX power-to-current table and helper in `energy_profiles`
- compute TX energy using the current table in `Simulator.step`
- test the new behavior for varying TX power levels

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687910dfe9908331a19a5f4eb2fd0a13