### PR TITLE
Add channel environment presets

### DIFF
--- a/simulateur_lora_sfrd_4.0/README.md
+++ b/simulateur_lora_sfrd_4.0/README.md
@@ -8,6 +8,7 @@ This repository contains a lightweight LoRa network simulator implemented in Pyt
 - Multi-channel radio support
 - Advanced channel model with loss and noise parameters
 - Configurable bandwidth and coding rate per channel
+- Preset propagation environments (urban/suburban/rural) for quick channel setup
 - Capture effect and a minimum interference time to ignore very short overlaps
 - Initial spreading factor and power selection
 - Full LoRaWAN ADR layer following the official specification (LinkADRReq/Ans,
@@ -62,6 +63,13 @@ python VERSION_4/run.py --nodes 50 --gateways 2 --channels 3 \
 
 # LoRaWAN demo with downlinks
 python VERSION_4/run.py --lorawan-demo --steps 100 --output lorawan.csv
+```
+
+Use a preset propagation environment from Python:
+
+```python
+from VERSION_4.launcher.channel import Channel
+suburban = Channel(environment="suburban")
 ```
 
 You can analyze the resulting CSV file with:

--- a/simulateur_lora_sfrd_4.0/VERSION_4/README.md
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/README.md
@@ -99,6 +99,13 @@ réception :
 - `noise_figure` : facteur de bruit du récepteur en dB.
 - `noise_floor_std` : écart-type de la variation aléatoire du bruit (dB).
 - `fast_fading_std` : amplitude du fading multipath en dB.
+- `environment` : preset rapide pour le modèle de propagation
+  (`urban`, `suburban` ou `rural`).
+
+```python
+from launcher.channel import Channel
+canal = Channel(environment="urban")
+```
 
 Ces valeurs influencent le calcul du RSSI et du SNR retournés par
 `Channel.compute_rssi`.

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/channel.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/channel.py
@@ -4,6 +4,12 @@ import random
 class Channel:
     """Représente le canal de propagation radio pour LoRa."""
 
+    ENV_PRESETS = {
+        "urban": (2.7, 6.0),
+        "suburban": (2.3, 4.0),
+        "rural": (2.0, 2.0),
+    }
+
     def __init__(
         self,
         frequency_hz: float = 868e6,
@@ -21,6 +27,7 @@ class Channel:
         tx_power_std: float = 0.0,
         interference_dB: float = 0.0,
         detection_threshold_dBm: float = -float("inf"),
+        environment: str | None = None,
     ):
         """
         Initialise le canal radio avec paramètres de propagation.
@@ -41,7 +48,18 @@ class Channel:
         :param interference_dB: Bruit supplémentaire moyen dû aux interférences.
         :param detection_threshold_dBm: RSSI minimal détectable (dBm). Les
             signaux plus faibles sont ignorés.
+        :param environment: Chaîne optionnelle pour charger un preset
+            ("urban", "suburban" ou "rural").
         """
+
+        if environment is not None:
+            env = environment.lower()
+            if env not in self.ENV_PRESETS:
+                raise ValueError(f"Unknown environment preset: {environment}")
+            path_loss_exp, shadowing_std = self.ENV_PRESETS[env]
+            self.environment = env
+        else:
+            self.environment = None
 
         self.frequency_hz = frequency_hz
         self.path_loss_exp = path_loss_exp

--- a/simulateur_lora_sfrd_4.0/tests/test_channel.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_channel.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from VERSION_4.launcher.channel import Channel  # noqa: E402
+import pytest
+
+
+def test_environment_preset_values():
+    ch = Channel(environment="rural")
+    assert ch.path_loss_exp == 2.0
+    assert ch.shadowing_std == 2.0
+
+
+def test_invalid_environment():
+    with pytest.raises(ValueError):
+        Channel(environment="unknown")


### PR DESCRIPTION
## Summary
- add environment presets to `Channel`
- document the feature in both READMEs
- demonstrate environment selection in example
- test environment presets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687910e691788331a1d7f31a07b73335