### PR TITLE
Support LoRaWAN Class B beacons and Class C continuous RX

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/node.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/node.py
@@ -120,9 +120,12 @@ class Node:
         self.last_adr_ack_req: bool = False
         self._nb_trans_left: int = 0
 
+        # Class B/C specific parameters
+        self.ping_slot_delay = 1.0 if class_type.upper() == "B" else 0.0
+
         # Energy accounting state
         self.last_state_time = 0.0
-        self.state = 'sleep'
+        self.state = 'rx' if class_type.upper() == 'C' else 'sleep'
 
     @property
     def battery_level(self) -> float:


### PR DESCRIPTION
## Summary
- implement beacon events and ping slot handling in `Simulator`
- keep Class C nodes in RX state outside of transmissions
- expose new class-specific attributes on `Node`
- test beacon scheduling and Class C continuous reception

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687910ef2a348331b2c19194b51bb181