### PR TITLE
Implement Class B beacons and Class C continuous RX

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/energy_profiles.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/energy_profiles.py
@@ -16,8 +16,8 @@ class EnergyProfile:
     voltage_v: float = 3.3
     sleep_current_a: float = 1e-6
     rx_current_a: float = 11e-3
-    process_current_a: float = 5e-3
-    rx_window_duration: float = 0.1
+    process_current_a: float = 0.0
+    rx_window_duration: float = 0.0
     tx_current_map_a: dict[float, float] | None = None
 
     def get_tx_current(self, power_dBm: float) -> float:

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/node.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/node.py
@@ -140,6 +140,8 @@ class Node:
         # Energy accounting state
         self.last_state_time = 0.0
         self.state = 'sleep'
+        if self.class_type.upper() == 'C':
+            self.state = 'rx'
 
     @property
     def battery_level(self) -> float:


### PR DESCRIPTION
## Summary
- add beacon and ping slot event types
- implement beacon scheduling and ping slots in Simulator
- keep Class C nodes in RX state and adjust energy model
- tweak default energy profile and add tests for beacon scheduling and Class C reception

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879159767e88331a395d5a2b1f91425