### PR TITLE
Fix zero battery nodes start inactive

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/node.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/node.py
@@ -86,9 +86,11 @@ class Node:
         self.packets_collision = 0
 
         # Batterie (énergie disponible restante)
-        self.battery_capacity_j = float('inf') if battery_capacity_j is None else battery_capacity_j
+        self.battery_capacity_j = (
+            float("inf") if battery_capacity_j is None else battery_capacity_j
+        )
         self.battery_remaining_j = self.battery_capacity_j
-        self.alive = True
+        self.alive = self.battery_remaining_j > 0
 
         # Paramètres de mobilité (initialement immobile)
         self.speed = 0.0       # Vitesse en m/s


### PR DESCRIPTION
## Summary
- initialize nodes as dead when battery capacity is zero

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879195b68608331b7bdb8c099ba8096