### PR TITLE
Fix CLI mode option case sensitivity

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/run.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/run.py
@@ -111,8 +111,9 @@ def main(argv=None):
     )
     parser.add_argument(
         "--mode",
-        choices=["Random", "Periodic"],
-        default="Random",
+        choices=["random", "periodic"],
+        default="random",
+        type=str.lower,
         help="Mode de transmission",
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
- allow lowercase values for `--mode` option in `run.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68791ca70ec083318ff601fb30808bbe