### PR TITLE
Add regional presets and MAC commands

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/lorawan.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/lorawan.py
@@ -86,6 +86,204 @@ class LinkCheckAns:
 
 
 @dataclass
+class DutyCycleReq:
+    max_duty_cycle: int
+
+    def to_bytes(self) -> bytes:
+        return bytes([0x04, self.max_duty_cycle & 0xFF])
+
+    @staticmethod
+    def from_bytes(data: bytes) -> "DutyCycleReq":
+        if len(data) < 2 or data[0] != 0x04:
+            raise ValueError("Invalid DutyCycleReq")
+        return DutyCycleReq(max_duty_cycle=data[1])
+
+
+@dataclass
+class RXParamSetupReq:
+    rx1_dr_offset: int
+    rx2_datarate: int
+    frequency: int
+
+    def to_bytes(self) -> bytes:
+        dl = ((self.rx1_dr_offset & 0x07) << 4) | (self.rx2_datarate & 0x0F)
+        freq = int(self.frequency / 100)
+        return bytes([0x05, dl]) + freq.to_bytes(3, "little")
+
+    @staticmethod
+    def from_bytes(data: bytes) -> "RXParamSetupReq":
+        if len(data) < 5 or data[0] != 0x05:
+            raise ValueError("Invalid RXParamSetupReq")
+        dl = data[1]
+        freq = int.from_bytes(data[2:5], "little") * 100
+        return RXParamSetupReq((dl >> 4) & 0x07, dl & 0x0F, freq)
+
+
+@dataclass
+class RXParamSetupAns:
+    status: int = 0b111
+
+    def to_bytes(self) -> bytes:
+        return bytes([0x05, self.status])
+
+
+@dataclass
+class DevStatusReq:
+    def to_bytes(self) -> bytes:
+        return bytes([0x06])
+
+
+@dataclass
+class DevStatusAns:
+    battery: int
+    margin: int
+
+    def to_bytes(self) -> bytes:
+        return bytes([0x06, self.battery & 0xFF, self.margin & 0xFF])
+
+    @staticmethod
+    def from_bytes(data: bytes) -> "DevStatusAns":
+        if len(data) < 3 or data[0] != 0x06:
+            raise ValueError("Invalid DevStatusAns")
+        return DevStatusAns(battery=data[1], margin=data[2])
+
+
+@dataclass
+class NewChannelReq:
+    ch_index: int
+    frequency: int
+    dr_range: int
+
+    def to_bytes(self) -> bytes:
+        freq = int(self.frequency / 100)
+        return (
+            bytes([0x07, self.ch_index & 0xFF])
+            + freq.to_bytes(3, "little")
+            + bytes([self.dr_range & 0xFF])
+        )
+
+    @staticmethod
+    def from_bytes(data: bytes) -> "NewChannelReq":
+        if len(data) < 6 or data[0] != 0x07:
+            raise ValueError("Invalid NewChannelReq")
+        freq = int.from_bytes(data[2:5], "little") * 100
+        return NewChannelReq(data[1], freq, data[5])
+
+
+@dataclass
+class NewChannelAns:
+    status: int = 0b11
+
+    def to_bytes(self) -> bytes:
+        return bytes([0x07, self.status])
+
+
+@dataclass
+class RXTimingSetupReq:
+    delay: int
+
+    def to_bytes(self) -> bytes:
+        return bytes([0x08, self.delay & 0xFF])
+
+    @staticmethod
+    def from_bytes(data: bytes) -> "RXTimingSetupReq":
+        if len(data) < 2 or data[0] != 0x08:
+            raise ValueError("Invalid RXTimingSetupReq")
+        return RXTimingSetupReq(delay=data[1])
+
+
+@dataclass
+class TxParamSetupReq:
+    eirp: int
+    dwell_time: int
+
+    def to_bytes(self) -> bytes:
+        param = ((self.eirp & 0x0F) << 4) | (self.dwell_time & 0x0F)
+        return bytes([0x09, param])
+
+    @staticmethod
+    def from_bytes(data: bytes) -> "TxParamSetupReq":
+        if len(data) < 2 or data[0] != 0x09:
+            raise ValueError("Invalid TxParamSetupReq")
+        param = data[1]
+        return TxParamSetupReq((param >> 4) & 0x0F, param & 0x0F)
+
+
+@dataclass
+class DlChannelReq:
+    ch_index: int
+    frequency: int
+
+    def to_bytes(self) -> bytes:
+        freq = int(self.frequency / 100)
+        return bytes([0x0A, self.ch_index & 0xFF]) + freq.to_bytes(3, "little")
+
+    @staticmethod
+    def from_bytes(data: bytes) -> "DlChannelReq":
+        if len(data) < 5 or data[0] != 0x0A:
+            raise ValueError("Invalid DlChannelReq")
+        freq = int.from_bytes(data[2:5], "little") * 100
+        return DlChannelReq(data[1], freq)
+
+
+@dataclass
+class DlChannelAns:
+    status: int = 0b11
+
+    def to_bytes(self) -> bytes:
+        return bytes([0x0A, self.status])
+
+
+@dataclass
+class PingSlotChannelReq:
+    frequency: int
+    dr: int
+
+    def to_bytes(self) -> bytes:
+        freq = int(self.frequency / 100)
+        return bytes([0x11]) + freq.to_bytes(3, "little") + bytes([self.dr & 0xFF])
+
+    @staticmethod
+    def from_bytes(data: bytes) -> "PingSlotChannelReq":
+        if len(data) < 5 or data[0] != 0x11:
+            raise ValueError("Invalid PingSlotChannelReq")
+        freq = int.from_bytes(data[1:4], "little") * 100
+        return PingSlotChannelReq(freq, data[4])
+
+
+@dataclass
+class PingSlotChannelAns:
+    status: int = 0b11
+
+    def to_bytes(self) -> bytes:
+        return bytes([0x11, self.status])
+
+
+@dataclass
+class BeaconFreqReq:
+    frequency: int
+
+    def to_bytes(self) -> bytes:
+        freq = int(self.frequency / 100)
+        return bytes([0x13]) + freq.to_bytes(3, "little")
+
+    @staticmethod
+    def from_bytes(data: bytes) -> "BeaconFreqReq":
+        if len(data) < 4 or data[0] != 0x13:
+            raise ValueError("Invalid BeaconFreqReq")
+        freq = int.from_bytes(data[1:4], "little") * 100
+        return BeaconFreqReq(freq)
+
+
+@dataclass
+class BeaconFreqAns:
+    status: int = 0b01
+
+    def to_bytes(self) -> bytes:
+        return bytes([0x13, self.status])
+
+
+@dataclass
 class DeviceTimeReq:
     """DeviceTimeReq MAC command"""
 

--- a/simulateur_lora_sfrd_4.0/tests/test_channel.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_channel.py
@@ -17,3 +17,15 @@ def test_environment_preset_values():
 def test_invalid_environment():
     with pytest.raises(ValueError):
         Channel(environment="unknown")
+
+
+def test_region_preset_single_channel():
+    ch = Channel(region="EU868", channel_index=1)
+    assert ch.region == "EU868"
+    assert ch.frequency_hz == Channel.REGION_CHANNELS["EU868"][1]
+
+
+def test_region_channels_helper_returns_list():
+    chans = Channel.region_channels("US915")
+    assert len(chans) == len(Channel.REGION_CHANNELS["US915"])
+    assert all(isinstance(c, Channel) for c in chans)

--- a/simulateur_lora_sfrd_4.0/tests/test_lorawan.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_lorawan.py
@@ -1,0 +1,33 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from VERSION_4.launcher.lorawan import (
+    NewChannelReq,
+    RXParamSetupReq,
+    DevStatusAns,
+)
+
+
+def test_new_channel_req_roundtrip():
+    req = NewChannelReq(1, 868300000, 0x22)
+    data = req.to_bytes()
+    parsed = NewChannelReq.from_bytes(data)
+    assert parsed == req
+
+
+def test_rx_param_setup_req_roundtrip():
+    req = RXParamSetupReq(3, 5, 869525000)
+    data = req.to_bytes()
+    parsed = RXParamSetupReq.from_bytes(data)
+    assert parsed == req
+
+
+def test_dev_status_ans_roundtrip():
+    ans = DevStatusAns(battery=200, margin=10)
+    data = ans.to_bytes()
+    parsed = DevStatusAns.from_bytes(data)
+    assert parsed == ans
+


### PR DESCRIPTION
## Summary
- allow Channel to be initialised from region frequency plans
- add helper to create channels for a region
- implement many LoRaWAN MAC command dataclasses
- add tests for new Channel features and MAC command round‐trips

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879203d818883319c8c081047ef02f3