### PR TITLE
Implement optional Rayleigh fading

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/README.md
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/README.md
@@ -99,6 +99,8 @@ réception :
 - `noise_figure` : facteur de bruit du récepteur en dB.
 - `noise_floor_std` : écart-type de la variation aléatoire du bruit (dB).
 - `fast_fading_std` : amplitude du fading multipath en dB.
+- `fading_model` : `"gaussian"` (défaut) ou `"rayleigh"` pour choisir le type de
+  fading multipath appliqué.
 - `environment` : preset rapide pour le modèle de propagation
   (`urban`, `suburban` ou `rural`).
 

--- a/simulateur_lora_sfrd_4.0/tests/test_channel.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_channel.py
@@ -17,3 +17,15 @@ def test_environment_preset_values():
 def test_invalid_environment():
     with pytest.raises(ValueError):
         Channel(environment="unknown")
+
+
+def test_invalid_fading_model():
+    with pytest.raises(ValueError):
+        Channel(fading_model="invalid")
+
+
+def test_rayleigh_fading_computation():
+    ch = Channel(fading_model="rayleigh", fast_fading_std=1.0, shadowing_std=0)
+    rssi, snr = ch.compute_rssi(14.0, 10.0)
+    assert isinstance(rssi, float)
+    assert isinstance(snr, float)


### PR DESCRIPTION
## Summary
- add `fading_model` parameter to `Channel`
- document new option
- unit tests for `fading_model`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68792056a0bc83318662327e6b4adeb4