### PR TITLE
Expose battery and LoRaWAN options in dashboard

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/README.md
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/README.md
@@ -87,6 +87,7 @@ Le tableau de bord permet maintenant de fixer une **durée réelle maximale** en
 ## Suivi de batterie
 
 Chaque nœud peut être doté d'une capacité d'énergie (en joules) grâce au paramètre `battery_capacity_j` du `Simulator`. La consommation est calculée selon le profil d'énergie FLoRa (courants typiques en veille, réception, etc.) puis retranchée de cette réserve. Le champ `battery_remaining_j` indique l'autonomie restante.
+Un champ **Capacité batterie (J)** est disponible dans le tableau de bord pour saisir facilement cette valeur (mettre `0` pour une capacité illimitée).
 
 ## Paramètres radio avancés
 
@@ -156,6 +157,8 @@ Lancer l'exemple minimal :
 ```bash
 python run.py --lorawan-demo
 ```
+
+Le tableau de bord inclut désormais un sélecteur **Classe LoRaWAN** permettant de choisir entre les modes A, B ou C pour l'ensemble des nœuds, ainsi qu'un champ **Taille payload (o)** afin de définir la longueur utilisée pour calculer l'airtime. Ces réglages facilitent la reproduction fidèle des scénarios FLoRa.
 
 ## Differences from FLoRa
 

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/dashboard.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/dashboard.py
@@ -95,6 +95,16 @@ detection_threshold_input = pn.widgets.FloatInput(
 min_interference_input = pn.widgets.FloatInput(
     name="Min interference (s)", value=0.0, step=0.1, start=0.0
 )
+# --- Paramètres supplémentaires ---
+battery_capacity_input = pn.widgets.FloatInput(
+    name="Capacité batterie (J)", value=0.0, step=10.0, start=0.0
+)
+payload_size_input = pn.widgets.IntInput(
+    name="Taille payload (o)", value=20, step=1, start=1
+)
+node_class_select = pn.widgets.RadioButtonGroup(
+    name="Classe LoRaWAN", options=["A", "B", "C"], value="A"
+)
 # Lorsque le mode FLoRa est activé, cette valeur est fixée à 5 s
 
 # --- Positions manuelles ---
@@ -290,6 +300,9 @@ def setup_simulation(seed_offset: int = 0):
         channel_distribution="random" if channel_dist_select.value == "Aléatoire" else "round-robin",
         fixed_sf=int(sf_value_input.value) if fixed_sf_checkbox.value else None,
         fixed_tx_power=float(tx_power_input.value) if fixed_power_checkbox.value else None,
+        battery_capacity_j=float(battery_capacity_input.value) if battery_capacity_input.value > 0 else None,
+        payload_size_bytes=int(payload_size_input.value),
+        node_class=node_class_select.value,
         detection_threshold_dBm=float(detection_threshold_input.value),
         min_interference_time=float(min_interference_input.value),
         seed=seed,
@@ -371,6 +384,9 @@ def setup_simulation(seed_offset: int = 0):
     flora_mode_toggle.disabled = True
     detection_threshold_input.disabled = True
     min_interference_input.disabled = True
+    battery_capacity_input.disabled = True
+    payload_size_input.disabled = True
+    node_class_select.disabled = True
     seed_input.disabled = True
     num_runs_input.disabled = True
     real_time_duration_input.disabled = True
@@ -464,6 +480,9 @@ def on_stop(event):
     flora_mode_toggle.disabled = False
     detection_threshold_input.disabled = False
     min_interference_input.disabled = False
+    battery_capacity_input.disabled = False
+    payload_size_input.disabled = False
+    node_class_select.disabled = False
     seed_input.disabled = False
     num_runs_input.disabled = False
     real_time_duration_input.disabled = False
@@ -694,6 +713,9 @@ controls = pn.WidgetBox(
     flora_mode_toggle,
     detection_threshold_input,
     min_interference_input,
+    battery_capacity_input,
+    payload_size_input,
+    node_class_select,
     real_time_duration_input,
     pn.Row(start_button, stop_button),
     pn.Row(fast_forward_button, pause_button),

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/simulator.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/simulator.py
@@ -57,6 +57,7 @@ class Simulator:
                  fixed_tx_power: float | None = None,
                  battery_capacity_j: float | None = None,
                  payload_size_bytes: int = 20,
+                 node_class: str = 'A',
                  detection_threshold_dBm: float = -float("inf"),
                  min_interference_time: float = 0.0,
                  seed: int | None = None,
@@ -85,6 +86,7 @@ class Simulator:
         :param fixed_tx_power: Si défini, puissance d'émission initiale commune (dBm).
         :param battery_capacity_j: Capacité de la batterie attribuée à chaque nœud (J). ``None`` pour illimité.
         :param payload_size_bytes: Taille du payload utilisé pour calculer l'airtime (octets).
+        :param node_class: Classe LoRaWAN commune à tous les nœuds ('A', 'B' ou 'C').
         :param detection_threshold_dBm: RSSI minimal requis pour qu'une
             réception soit prise en compte.
         :param min_interference_time: Chevauchement temporel toléré entre
@@ -108,6 +110,7 @@ class Simulator:
         self.fixed_tx_power = fixed_tx_power
         self.battery_capacity_j = battery_capacity_j
         self.payload_size_bytes = payload_size_bytes
+        self.node_class = node_class
         self.detection_threshold_dBm = detection_threshold_dBm
         self.min_interference_time = min_interference_time
         # Activation ou non de la mobilité des nœuds
@@ -178,8 +181,16 @@ class Simulator:
             sf = self.fixed_sf if self.fixed_sf is not None else random.randint(7, 12)
             tx_power = self.fixed_tx_power if self.fixed_tx_power is not None else 14.0
             channel = self.multichannel.select_mask(0xFFFF)
-            node = Node(node_id, x, y, sf, tx_power, channel=channel,
-                        battery_capacity_j=self.battery_capacity_j)
+            node = Node(
+                node_id,
+                x,
+                y,
+                sf,
+                tx_power,
+                channel=channel,
+                class_type=self.node_class,
+                battery_capacity_j=self.battery_capacity_j,
+            )
             # Enregistrer les états initiaux du nœud pour rapport ultérieur
             node.initial_x = x
             node.initial_y = y


### PR DESCRIPTION
## Summary
- allow choosing node class when building a `Simulator`
- expose battery capacity, payload size and node class on the dashboard
- document the new dashboard fields in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687925a20e5c8331a6b41659f16eda0c