### PR TITLE
Add extended LoRaWAN MAC command support

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/__init__.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/__init__.py
@@ -8,6 +8,7 @@ from .simulator import Simulator
 from .duty_cycle import DutyCycleManager
 from .smooth_mobility import SmoothMobility
 from .lorawan import LoRaWANFrame, compute_rx1, compute_rx2
+from .downlink_scheduler import DownlinkScheduler
 
 __all__ = [
     "Node",
@@ -21,6 +22,7 @@ __all__ = [
     "LoRaWANFrame",
     "compute_rx1",
     "compute_rx2",
+    "DownlinkScheduler",
 ]
 
 for name in __all__:

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/downlink_scheduler.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/downlink_scheduler.py
@@ -1,0 +1,26 @@
+class DownlinkScheduler:
+    """Simple scheduler for downlink frames for class B/C nodes."""
+
+    def __init__(self):
+        self.queue: dict[int, list[tuple[float, object, object]]] = {}
+
+    def schedule(self, node_id: int, time: float, frame, gateway):
+        """Schedule a frame for a given node at ``time`` via ``gateway``."""
+        self.queue.setdefault(node_id, []).append((time, frame, gateway))
+
+    def pop_ready(self, node_id: int, current_time: float):
+        """Return the next ready frame for ``node_id`` if any."""
+        q = self.queue.get(node_id)
+        if not q:
+            return None, None
+        q.sort(key=lambda x: x[0])
+        if q[0][0] <= current_time:
+            _, frame, gw = q.pop(0)
+            return frame, gw
+        return None, None
+
+    def next_time(self, node_id: int):
+        q = self.queue.get(node_id)
+        if not q:
+            return None
+        return min(t for t, _, _ in q)

--- a/simulateur_lora_sfrd_4.0/tests/test_mac_commands_extended.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_mac_commands_extended.py
@@ -1,0 +1,50 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from VERSION_4.launcher.node import Node
+from VERSION_4.launcher.channel import Channel
+from VERSION_4.launcher.lorawan import (
+    LoRaWANFrame,
+    DutyCycleReq,
+    RXParamSetupReq,
+    DevStatusReq,
+    DevStatusAns,
+    PingSlotChannelReq,
+)
+
+
+def test_handle_duty_cycle_req():
+    node = Node(1, 0.0, 0.0, 7, 14.0, channel=Channel())
+    frame = LoRaWANFrame(0, 0, 0, DutyCycleReq(3).to_bytes())
+    node.handle_downlink(frame)
+    assert node.max_duty_cycle == 3
+
+
+def test_handle_rx_param_setup_req():
+    node = Node(1, 0.0, 0.0, 7, 14.0, channel=Channel())
+    req = RXParamSetupReq(1, 5, 869525000)
+    frame = LoRaWANFrame(0, 0, 0, req.to_bytes())
+    node.handle_downlink(frame)
+    assert node.rx1_dr_offset == 1
+    assert node.rx2_datarate == 5
+    assert node.rx2_frequency == 869525000
+
+
+def test_handle_dev_status_req():
+    node = Node(1, 0.0, 0.0, 7, 14.0, channel=Channel())
+    frame = LoRaWANFrame(0, 0, 0, DevStatusReq().to_bytes())
+    node.handle_downlink(frame)
+    ans = DevStatusAns.from_bytes(node.pending_mac_cmd)
+    assert ans.battery == 255
+
+
+def test_handle_ping_slot_channel_req():
+    node = Node(1, 0.0, 0.0, 7, 14.0, channel=Channel())
+    req = PingSlotChannelReq(869525000, 3)
+    frame = LoRaWANFrame(0, 0, 0, req.to_bytes())
+    node.handle_downlink(frame)
+    assert node.ping_slot_frequency == 869525000
+    assert node.ping_slot_dr == 3


### PR DESCRIPTION
## Summary
- extend Node with fields for MAC command parameters
- support additional MAC commands in `handle_downlink`
- add a simple `DownlinkScheduler` helper module
- export new class via package `__init__`
- test handling of new MAC commands

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687928dd3bf883318031a7d349c98c22