### PR TITLE
Fix SNR computation in AdvancedChannel

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/advanced_channel.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/advanced_channel.py
@@ -52,10 +52,14 @@ class AdvancedChannel:
 
     # ------------------------------------------------------------------
     def compute_rssi(self, tx_power_dBm: float, distance: float) -> tuple[float, float]:
-        rssi, _ = self.base.compute_rssi(tx_power_dBm, distance)
-        # remove previous fading then apply new
+        """Return RSSI and SNR for the advanced channel."""
+        base_rssi, base_snr = self.base.compute_rssi(tx_power_dBm, distance)
+        noise = base_rssi - base_snr
+
+        rssi = base_rssi
         if self.fading == "rayleigh":
             u = random.random()
             rayleigh = math.sqrt(-2.0 * math.log(max(u, 1e-12)))
             rssi += 20 * math.log10(rayleigh)
-        return rssi, rssi - self.base.noise_floor_dBm()
+
+        return rssi, rssi - noise


### PR DESCRIPTION
## Summary
- fix the SNR calculation in `AdvancedChannel.compute_rssi`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68792c2799988331b2cefb9cbb955c37