### PR TITLE
Compute PDR metrics by node class

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/simulator.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/simulator.py
@@ -689,6 +689,14 @@ class Simulator:
                 gateway_counts[gw_id] += 1
         pdr_by_gateway = {gw_id: count / total_sent if total_sent > 0 else 0.0 for gw_id, count in gateway_counts.items()}
 
+        pdr_by_class: dict[str, float] = {}
+        class_types = {n.class_type for n in self.nodes}
+        for ct in class_types:
+            nodes_cls = [n for n in self.nodes if n.class_type == ct]
+            sent_cls = sum(n.packets_sent for n in nodes_cls)
+            delivered_cls = sum(n.packets_success for n in nodes_cls)
+            pdr_by_class[ct] = delivered_cls / sent_cls if sent_cls > 0 else 0.0
+
         return {
             'PDR': pdr,
             'collisions': self.packets_lost_collision,
@@ -700,6 +708,7 @@ class Simulator:
             'recent_pdr_by_node': recent_pdr_by_node,
             'pdr_by_sf': pdr_by_sf,
             'pdr_by_gateway': pdr_by_gateway,
+            'pdr_by_class': pdr_by_class,
             'retransmissions': self.retransmissions,
         }
 

--- a/simulateur_lora_sfrd_4.0/tests/test_simulator.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_simulator.py
@@ -104,6 +104,19 @@ def test_metrics_retransmissions():
     assert sim.packets_sent == 2
 
 
+def test_metrics_pdr_by_class():
+    sim = _make_sim(num_nodes=2, same_start=False)
+    sim.nodes[0].class_type = "A"
+    sim.nodes[1].class_type = "C"
+    while sim.step():
+        pass
+    metrics = sim.get_metrics()
+    assert "pdr_by_class" in metrics
+    assert set(metrics["pdr_by_class"].keys()) == {"A", "C"}
+    assert metrics["pdr_by_class"]["A"] == pytest.approx(1.0)
+    assert metrics["pdr_by_class"]["C"] == pytest.approx(1.0)
+
+
 def test_lorawan_frame_handling():
     node = Node(1, 0.0, 0.0, 7, 14.0, channel=Channel())
     up = node.prepare_uplink(b"ping", confirmed=True)


### PR DESCRIPTION
## Summary
- extend `get_metrics()` to aggregate PDR by node class
- expose the new `pdr_by_class` metric
- test that each node class yields its own PDR value

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68793041565883318a8cb7c557428e3e