### PR TITLE
Extend LoRaWAN MAC command handling

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/lorawan.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/lorawan.py
@@ -260,6 +260,30 @@ class PingSlotChannelAns:
 
 
 @dataclass
+class PingSlotInfoReq:
+    """Request the network server to return the ping slot periodicity."""
+
+    periodicity: int
+
+    def to_bytes(self) -> bytes:
+        return bytes([0x10, self.periodicity & 0x07])
+
+    @staticmethod
+    def from_bytes(data: bytes) -> "PingSlotInfoReq":
+        if len(data) < 2 or data[0] != 0x10:
+            raise ValueError("Invalid PingSlotInfoReq")
+        return PingSlotInfoReq(data[1] & 0x07)
+
+
+@dataclass
+class PingSlotInfoAns:
+    """Acknowledge a PingSlotInfoReq."""
+
+    def to_bytes(self) -> bytes:
+        return bytes([0x10])
+
+
+@dataclass
 class BeaconFreqReq:
     frequency: int
 
@@ -281,6 +305,37 @@ class BeaconFreqAns:
 
     def to_bytes(self) -> bytes:
         return bytes([0x13, self.status])
+
+
+@dataclass
+class BeaconTimingReq:
+    """Request the delay and channel of the next beacon."""
+
+    def to_bytes(self) -> bytes:
+        return bytes([0x12])
+
+    @staticmethod
+    def from_bytes(data: bytes) -> "BeaconTimingReq":
+        if len(data) < 1 or data[0] != 0x12:
+            raise ValueError("Invalid BeaconTimingReq")
+        return BeaconTimingReq()
+
+
+@dataclass
+class BeaconTimingAns:
+    delay: int
+    channel: int
+
+    def to_bytes(self) -> bytes:
+        return bytes([0x12]) + self.delay.to_bytes(2, "little") + bytes([self.channel & 0xFF])
+
+    @staticmethod
+    def from_bytes(data: bytes) -> "BeaconTimingAns":
+        if len(data) < 4 or data[0] != 0x12:
+            raise ValueError("Invalid BeaconTimingAns")
+        delay = int.from_bytes(data[1:3], "little")
+        channel = data[3]
+        return BeaconTimingAns(delay, channel)
 
 
 @dataclass

--- a/simulateur_lora_sfrd_4.0/tests/test_lorawan.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_lorawan.py
@@ -10,6 +10,8 @@ from VERSION_4.launcher.lorawan import (
     NewChannelReq,
     RXParamSetupReq,
     DevStatusAns,
+    PingSlotInfoReq,
+    BeaconTimingAns,
 )
 
 
@@ -31,6 +33,20 @@ def test_dev_status_ans_roundtrip():
     ans = DevStatusAns(battery=200, margin=10)
     data = ans.to_bytes()
     parsed = DevStatusAns.from_bytes(data)
+    assert parsed == ans
+
+
+def test_ping_slot_info_req_roundtrip():
+    req = PingSlotInfoReq(5)
+    data = req.to_bytes()
+    parsed = PingSlotInfoReq.from_bytes(data)
+    assert parsed == req
+
+
+def test_beacon_timing_ans_roundtrip():
+    ans = BeaconTimingAns(256, 3)
+    data = ans.to_bytes()
+    parsed = BeaconTimingAns.from_bytes(data)
     assert parsed == ans
 
 

--- a/simulateur_lora_sfrd_4.0/tests/test_mac_commands_extended.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_mac_commands_extended.py
@@ -13,6 +13,10 @@ from VERSION_4.launcher.lorawan import (
     DevStatusReq,
     DevStatusAns,
     PingSlotChannelReq,
+    PingSlotInfoReq,
+    PingSlotInfoAns,
+    BeaconTimingReq,
+    BeaconTimingAns,
 )
 
 
@@ -48,3 +52,21 @@ def test_handle_ping_slot_channel_req():
     node.handle_downlink(frame)
     assert node.ping_slot_frequency == 869525000
     assert node.ping_slot_dr == 3
+
+
+def test_handle_ping_slot_info_req():
+    node = Node(1, 0.0, 0.0, 7, 14.0, channel=Channel())
+    req = PingSlotInfoReq(2)
+    frame = LoRaWANFrame(0, 0, 0, req.to_bytes())
+    node.handle_downlink(frame)
+    assert node.ping_slot_periodicity == 2
+    assert node.pending_mac_cmd == PingSlotInfoAns().to_bytes()
+
+
+def test_handle_beacon_timing_req():
+    node = Node(1, 0.0, 0.0, 7, 14.0, channel=Channel())
+    frame = LoRaWANFrame(0, 0, 0, BeaconTimingReq().to_bytes())
+    node.handle_downlink(frame)
+    ans = BeaconTimingAns.from_bytes(node.pending_mac_cmd)
+    assert ans.delay == 0
+    assert ans.channel == 0


### PR DESCRIPTION
## Summary
- add new MAC command dataclasses: `PingSlotInfoReq/Ans` and `BeaconTimingReq/Ans`
- track ping slot periodicity and beacon timing in `Node`
- process the new commands in `Node.handle_downlink`
- add tests for the dataclasses and handlers

## Testing
- `pytest -q tests/test_lorawan.py tests/test_mac_commands_extended.py -q`
- `pytest -q` *(failsafe full test run, interrupted after completion)*

------
https://chatgpt.com/codex/tasks/task_e_687937af4c3883319d41ea4c839043e8