### PR TITLE
Expose per-node PDR metrics

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/README.md
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/README.md
@@ -285,10 +285,9 @@ Ce projet est distribué sous licence [MIT](../LICENSE).
 
 ## Améliorations possibles
 
-Pour aller plus loin, on pourrait :
+Les points suivants ont été intégrés au simulateur :
 
-- **Calculer des PDR par nœud ou par type de trafic.** Chaque nœud dispose déjà d'un historique de ses transmissions. On peut ainsi déterminer un taux de livraison individuel ou différencié suivant la classe ou le mode d'envoi.
-- **Conserver un historique glissant pour afficher un PDR moyen sur les dernières transmissions.** Le simulateur stocke désormais les vingt derniers événements de chaque nœud et calcule un PDR « récent ».
-- **Ajouter des indicateurs supplémentaires :** PDR par SF, par passerelle et par nœud sont exposés via la méthode `get_metrics()`.
-- **Intégrer des métriques de QoS :** délai moyen et nombre de retransmissions sont suivis pour affiner la vision du réseau.
+- **PDR par nœud et par type de trafic.** Chaque nœud maintient l'historique de ses vingt dernières transmissions afin de calculer un taux de livraison global et récent. Ces valeurs sont visibles dans le tableau de bord et exportées dans un fichier `metrics_*.csv`.
+- **Historique glissant et indicateurs QoS.** Le simulateur calcule désormais le délai moyen de livraison ainsi que le nombre de retransmissions sur la période récente.
+- **Indicateurs supplémentaires.** La méthode `get_metrics()` retourne le PDR par SF, passerelle, classe et nœud. Le tableau de bord affiche un récapitulatif et l'export produit deux fichiers CSV : un pour les événements détaillés et un pour les métriques agrégées.
 

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/dashboard.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/dashboard.py
@@ -133,6 +133,13 @@ energy_indicator = pn.indicators.Number(name="Énergie Tx (J)", value=0.0, forma
 delay_indicator = pn.indicators.Number(name="Délai moyen (s)", value=0.0, format="{value:.3f}")
 throughput_indicator = pn.indicators.Number(name="Débit (bps)", value=0.0, format="{value:.2f}")
 
+# Tableau récapitulatif du PDR par nœud (global et récent)
+pdr_table = pn.pane.DataFrame(
+    pd.DataFrame(columns=["Node", "PDR", "Recent PDR"]),
+    height=200,
+    width=220,
+)
+
 # --- Chronomètre ---
 chrono_indicator = pn.indicators.Number(name="Durée simulation (s)", value=0, format="{value:.1f}")
 
@@ -252,6 +259,17 @@ def step_simulation():
     energy_indicator.value = metrics["energy_J"]
     delay_indicator.value = metrics["avg_delay_s"]
     throughput_indicator.value = metrics["throughput_bps"]
+    table_df = pd.DataFrame(
+        {
+            "Node": list(metrics["pdr_by_node"].keys()),
+            "PDR": list(metrics["pdr_by_node"].values()),
+            "Recent PDR": [
+                metrics["recent_pdr_by_node"][nid]
+                for nid in metrics["pdr_by_node"].keys()
+            ],
+        }
+    )
+    pdr_table.object = table_df
     sf_dist = metrics["sf_distribution"]
     sf_fig = go.Figure(
         data=[go.Bar(x=[f"SF{sf}" for sf in sf_dist.keys()], y=list(sf_dist.values()))]
@@ -509,12 +527,24 @@ def on_stop(event):
         energy_indicator.value = avg.get("energy_J", 0.0)
         delay_indicator.value = avg.get("avg_delay_s", 0.0)
         throughput_indicator.value = avg.get("throughput_bps", 0.0)
+        last = runs_metrics[-1]
+        table_df = pd.DataFrame(
+            {
+                "Node": list(last["pdr_by_node"].keys()),
+                "PDR": list(last["pdr_by_node"].values()),
+                "Recent PDR": [
+                    last["recent_pdr_by_node"][nid]
+                    for nid in last["pdr_by_node"].keys()
+                ],
+            }
+        )
+        pdr_table.object = table_df
     export_message.object = "✅ Simulation terminée. Tu peux exporter les résultats."
 
 
 # --- Export CSV local : Méthode universelle ---
 def exporter_csv(event=None):
-    global runs_events
+    global runs_events, runs_metrics
     if runs_events:
         try:
             df = pd.concat(runs_events, ignore_index=True)
@@ -524,7 +554,13 @@ def exporter_csv(event=None):
             timestamp = time.strftime("%Y-%m-%d_%H-%M-%S")
             chemin = os.path.join(os.getcwd(), f"resultats_simulation_{timestamp}.csv")
             df.to_csv(chemin, index=False, encoding="utf-8")
-            export_message.object = f"✅ Résultats exportés : <b>{chemin}</b><br>(Ouvre-le avec Excel ou pandas)"
+            metrics_path = os.path.join(os.getcwd(), f"metrics_{timestamp}.csv")
+            if runs_metrics:
+                pd.DataFrame(runs_metrics).to_csv(metrics_path, index=False, encoding="utf-8")
+            export_message.object = (
+                f"✅ Résultats exportés : <b>{chemin}</b><br>"
+                f"Métriques : <b>{metrics_path}</b><br>(Ouvre-les avec Excel ou pandas)"
+            )
             try:
                 os.startfile(os.getcwd())
             except Exception:
@@ -731,6 +767,7 @@ metrics_col = pn.Column(
     energy_indicator,
     delay_indicator,
     throughput_indicator,
+    pdr_table,
 )
 metrics_col.width = 220
 


### PR DESCRIPTION
## Summary
- show a table with the global and recent PDR of each node in the dashboard
- export run metrics to a `metrics_*.csv` file along with the events CSV
- document the new metrics in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879380c37908331ac1c82c4170a7603