### PR TITLE
Add FLoRa validation helpers

### DIFF
--- a/simulateur_lora_sfrd_4.0/.gitignore
+++ b/simulateur_lora_sfrd_4.0/.gitignore
@@ -11,4 +11,5 @@ env/
 
 # Results and user-generated files
 *.csv
+!tests/data/*.csv
 pdr_par_nodes.png

--- a/simulateur_lora_sfrd_4.0/README.md
+++ b/simulateur_lora_sfrd_4.0/README.md
@@ -123,6 +123,15 @@ pytest -q
 
 The tests compare RSSI and airtime calculations against theoretical values and check collision handling.
 
+### Cross-check with FLoRa
+
+The module `VERSION_4/launcher/compare_flora.py` reads CSV exports from
+the FLoRa simulator and extracts the Packet Delivery Ratio and the
+spreading factor histogram. The test file
+`tests/test_flora_comparison.py` demonstrates how to compare these
+values with those returned by `Simulator.get_metrics` to validate the
+Python implementation against OMNeT++ runs.
+
 ## Versioning
 
 The current package version is defined in `pyproject.toml`.

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/compare_flora.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/compare_flora.py
@@ -1,0 +1,42 @@
+"""Utilities to compare simulator results against FLoRa output."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+
+def load_flora_metrics(csv_path: str | Path) -> dict[str, Any]:
+    """Return PDR and SF histogram from a FLoRa CSV export."""
+    df = pd.read_csv(csv_path)
+    total_sent = int(df["sent"].sum()) if "sent" in df.columns else 0
+    total_recv = int(df["received"].sum()) if "received" in df.columns else 0
+    pdr = total_recv / total_sent if total_sent else 0.0
+    sf_cols = [c for c in df.columns if c.startswith("sf")]
+    sf_hist = {int(c[2:]): int(df[c].sum()) for c in sf_cols}
+    return {"PDR": pdr, "sf_distribution": sf_hist}
+
+
+def compare_with_sim(sim_metrics: dict[str, Any], flora_csv: str | Path, *, pdr_tol: float = 0.05) -> bool:
+    """Compare simulator metrics with FLoRa results.
+
+    Parameters
+    ----------
+    sim_metrics : dict
+        Metrics returned by :meth:`Simulator.get_metrics`.
+    flora_csv : str | Path
+        Path to the FLoRa CSV export to compare against.
+    pdr_tol : float, optional
+        Accepted absolute tolerance on the PDR difference. Defaults to ``0.05``.
+
+    Returns
+    -------
+    bool
+        ``True`` if the metrics match within tolerance.
+    """
+    flora_metrics = load_flora_metrics(flora_csv)
+    pdr_match = abs(sim_metrics.get("PDR", 0.0) - flora_metrics["PDR"]) <= pdr_tol
+    sf_match = sim_metrics.get("sf_distribution") == flora_metrics["sf_distribution"]
+    return pdr_match and sf_match

--- a/simulateur_lora_sfrd_4.0/tests/data/flora_sample.csv
+++ b/simulateur_lora_sfrd_4.0/tests/data/flora_sample.csv
@@ -1,0 +1,2 @@
+run,sent,received,sf7,sf8,sf9,sf10,sf11,sf12
+1,2,2,2,0,0,0,0,0

--- a/simulateur_lora_sfrd_4.0/tests/test_flora_comparison.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_flora_comparison.py
@@ -1,0 +1,49 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pandas")
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from VERSION_4.launcher.channel import Channel
+from VERSION_4.launcher.simulator import Simulator
+from VERSION_4.launcher.compare_flora import load_flora_metrics, compare_with_sim
+
+
+def _make_sim(num_nodes: int) -> Simulator:
+    ch = Channel(shadowing_std=0)
+    sim = Simulator(
+        num_nodes=num_nodes,
+        num_gateways=1,
+        area_size=10.0,
+        transmission_mode="Periodic",
+        packet_interval=10.0,
+        packets_to_send=num_nodes,
+        mobility=False,
+        duty_cycle=None,
+        channels=[ch],
+        fixed_sf=7,
+        fixed_tx_power=14.0,
+    )
+    gw = sim.gateways[0]
+    for idx, node in enumerate(sim.nodes):
+        node.x = gw.x
+        node.y = gw.y
+    sim.event_queue.clear()
+    sim.event_id_counter = 0
+    for idx, node in enumerate(sim.nodes):
+        sim.schedule_event(node, idx * 1.0)
+    return sim
+
+
+def test_compare_with_flora_sample():
+    sim = _make_sim(num_nodes=2)
+    sim.run()
+    metrics = sim.get_metrics()
+    flora_csv = Path(__file__).parent / "data" / "flora_sample.csv"
+    flora_metrics = load_flora_metrics(flora_csv)
+    assert metrics["PDR"] == pytest.approx(flora_metrics["PDR"])
+    assert compare_with_sim(metrics, flora_csv)


### PR DESCRIPTION
## Summary
- add a helper module `compare_flora.py` to read FLoRa CSV results
- provide a test and sample FLoRa results
- document how to cross-check metrics against OMNeT++ output
- allow CSV test data in `.gitignore`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68793ef6320c83318c98e195e2a4c5cb