### PR TITLE
Fix missing lorawan_minor attribute

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/node.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/node.py
@@ -141,6 +141,8 @@ class Node:
         self.ping_slot_periodicity: int | None = None
         self.beacon_delay: int | None = None
         self.beacon_channel: int | None = None
+        # LoRaWAN minor version (ResetInd/Conf). Default 0 as per spec
+        self.lorawan_minor: int = 0
 
         # ADR state (LoRaWAN specification)
         self.adr = True


### PR DESCRIPTION
## Summary
- ensure `Node` instances always have a `lorawan_minor` attribute

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68794661abe48331bd59e008e87f2d84