### PR TITLE
Implement ping slot scheduling for class B

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/downlink_scheduler.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/downlink_scheduler.py
@@ -16,6 +16,23 @@ class DownlinkScheduler:
         )
         self._counter += 1
 
+    def schedule_class_b(
+        self,
+        node,
+        after_time: float,
+        frame,
+        gateway,
+        beacon_interval: float,
+        ping_slot_interval: float,
+        ping_slot_offset: float,
+    ) -> float:
+        """Schedule ``frame`` for ``node`` at its next ping slot."""
+        t = node.next_ping_slot_time(
+            after_time, beacon_interval, ping_slot_interval, ping_slot_offset
+        )
+        self.schedule(node.id, t, frame, gateway)
+        return t
+
     def pop_ready(self, node_id: int, current_time: float):
         """Return the next ready frame for ``node_id`` if any."""
         q = self.queue.get(node_id)

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/simulator.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/simulator.py
@@ -595,6 +595,7 @@ class Simulator:
             end_of_cycle = nxt
             for n in self.nodes:
                 if n.class_type.upper() == "B":
+                    n.last_beacon_time = time
                     periodicity = 2 ** (getattr(n, "ping_slot_periodicity", 0) or 0)
                     interval = self.ping_slot_interval * periodicity
                     slot = time + self.ping_slot_offset

--- a/simulateur_lora_sfrd_4.0/tests/test_downlink_bc.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_downlink_bc.py
@@ -1,0 +1,76 @@
+import sys
+from pathlib import Path
+import heapq
+
+# Allow importing the VERSION_4 package from the repository root
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from VERSION_4.launcher.channel import Channel  # noqa: E402
+from VERSION_4.launcher.simulator import Simulator, Event, EventType  # noqa: E402
+
+
+def _make_sim(class_type: str) -> Simulator:
+    ch = Channel(shadowing_std=0)
+    sim = Simulator(
+        num_nodes=1,
+        num_gateways=1,
+        area_size=10.0,
+        transmission_mode="Periodic",
+        packet_interval=10.0,
+        packets_to_send=1,
+        mobility=False,
+        duty_cycle=None,
+        channels=[ch],
+        fixed_sf=7,
+        fixed_tx_power=14.0,
+    )
+    node = sim.nodes[0]
+    node.class_type = class_type
+    node.x = sim.gateways[0].x
+    node.y = sim.gateways[0].y
+    return sim
+
+
+def test_downlink_delivery_class_c():
+    sim = _make_sim("C")
+    node = sim.nodes[0]
+    gw = sim.gateways[0]
+    sim.event_queue.clear()
+    sim.event_id_counter = 0
+    heapq.heappush(sim.event_queue, Event(0.0, EventType.RX_WINDOW, 0, node.id))
+    sim.network_server.send_downlink(node, b"data")
+    while sim.step():
+        if sim.current_time > sim.class_c_rx_interval + 0.1:
+            break
+    assert node.fcnt_down == 1
+    assert node.downlink_pending == 0
+
+
+def test_scheduler_programs_class_b_slot():
+    sim = _make_sim("B")
+    node = sim.nodes[0]
+    gw = sim.gateways[0]
+    sim.event_queue.clear()
+    sim.event_id_counter = 0
+    heapq.heappush(sim.event_queue, Event(0.0, EventType.RX_WINDOW, 0, node.id))
+    heapq.heappush(sim.event_queue, Event(0.0, EventType.BEACON, 1, 0))
+    from VERSION_4.launcher.lorawan import LoRaWANFrame
+
+    frame = LoRaWANFrame(mhdr=0x60, fctrl=0, fcnt=0, payload=b"data")
+    t = sim.network_server.scheduler.schedule_class_b(
+        node,
+        0.0,
+        frame,
+        gw,
+        sim.beacon_interval,
+        sim.ping_slot_interval,
+        sim.ping_slot_offset,
+    )
+    while sim.step():
+        if sim.current_time > t + 0.1:
+            break
+    assert node.fcnt_down == 1
+    assert node.downlink_pending == 0
+    assert t == sim.ping_slot_offset
+


### PR DESCRIPTION
## Summary
- extend Node with beacon tracking and ping slot helper
- update Simulator beacon event to store last beacon time
- add a scheduling helper for class B downlinks
- add tests for class B/C downlink reception

## Testing
- `pytest tests/test_downlink_bc.py::test_scheduler_programs_class_b_slot -q`
- `pytest tests/test_downlink_bc.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68796396594083319cbf82f58e1093a6