### PR TITLE
Etendre comparaison FLoRa et tests

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/compare_flora.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/compare_flora.py
@@ -9,17 +9,48 @@ import pandas as pd
 
 
 def load_flora_metrics(csv_path: str | Path) -> dict[str, Any]:
-    """Return PDR and SF histogram from a FLoRa CSV export."""
+    """Return common metrics aggregated from a FLoRa CSV export."""
+
     df = pd.read_csv(csv_path)
+
     total_sent = int(df["sent"].sum()) if "sent" in df.columns else 0
     total_recv = int(df["received"].sum()) if "received" in df.columns else 0
+    total_col = int(df["collisions"].sum()) if "collisions" in df.columns else 0
     pdr = total_recv / total_sent if total_sent else 0.0
-    sf_cols = [c for c in df.columns if c.startswith("sf")]
+
+    sf_cols = [c for c in df.columns if c.startswith("sf") and c[2:].isdigit()]
     sf_hist = {int(c[2:]): int(df[c].sum()) for c in sf_cols}
-    return {"PDR": pdr, "sf_distribution": sf_hist}
+
+    energy_col = None
+    for c in ("energy_J", "energy"):
+        if c in df.columns:
+            energy_col = c
+            break
+    total_energy = float(df[energy_col].sum()) if energy_col else 0.0
+
+    throughput = float(df["throughput_bps"].mean()) if "throughput_bps" in df.columns else 0.0
+
+    coll_cols = [c for c in df.columns if c.startswith("collisions_sf")]
+    coll_dist = {int(c.split("sf")[1]): int(df[c].sum()) for c in coll_cols}
+
+    return {
+        "PDR": pdr,
+        "sf_distribution": sf_hist,
+        "throughput_bps": throughput,
+        "energy_J": total_energy,
+        "collisions": total_col,
+        "collisions_distribution": coll_dist,
+    }
 
 
-def compare_with_sim(sim_metrics: dict[str, Any], flora_csv: str | Path, *, pdr_tol: float = 0.05) -> bool:
+def compare_with_sim(
+    sim_metrics: dict[str, Any],
+    flora_csv: str | Path,
+    *,
+    pdr_tol: float = 0.05,
+    throughput_tol: float = 0.05,
+    energy_tol: float = 0.05,
+) -> bool:
     """Compare simulator metrics with FLoRa results.
 
     Parameters
@@ -37,6 +68,32 @@ def compare_with_sim(sim_metrics: dict[str, Any], flora_csv: str | Path, *, pdr_
         ``True`` if the metrics match within tolerance.
     """
     flora_metrics = load_flora_metrics(flora_csv)
+
     pdr_match = abs(sim_metrics.get("PDR", 0.0) - flora_metrics["PDR"]) <= pdr_tol
+
     sf_match = sim_metrics.get("sf_distribution") == flora_metrics["sf_distribution"]
-    return pdr_match and sf_match
+
+    th_match = True
+    if "throughput_bps" in sim_metrics and flora_metrics.get("throughput_bps"):
+        ref = max(flora_metrics["throughput_bps"], 1.0)
+        th_match = (
+            abs(sim_metrics["throughput_bps"] - flora_metrics["throughput_bps"])
+            <= throughput_tol * ref
+        )
+
+    energy_match = True
+    if "energy_J" in sim_metrics and flora_metrics.get("energy_J"):
+        ref = max(flora_metrics["energy_J"], 1.0)
+        energy_match = (
+            abs(sim_metrics["energy_J"] - flora_metrics["energy_J"])
+            <= energy_tol * ref
+        )
+
+    coll_match = True
+    if "collisions_distribution" in sim_metrics and flora_metrics.get("collisions_distribution"):
+        coll_match = (
+            sim_metrics["collisions_distribution"]
+            == flora_metrics["collisions_distribution"]
+        )
+
+    return pdr_match and sf_match and th_match and energy_match and coll_match

--- a/simulateur_lora_sfrd_4.0/tests/data/flora_collision.csv
+++ b/simulateur_lora_sfrd_4.0/tests/data/flora_collision.csv
@@ -1,0 +1,2 @@
+run,sent,received,collisions,energy_J,throughput_bps,sf7,sf8,sf9,sf10,sf11,sf12,collisions_sf7,collisions_sf8,collisions_sf9,collisions_sf10,collisions_sf11,collisions_sf12
+1,3,1,2,0.033606,77.799216,3,0,0,0,0,0,2,0,0,0,0,0

--- a/simulateur_lora_sfrd_4.0/tests/data/flora_extended.csv
+++ b/simulateur_lora_sfrd_4.0/tests/data/flora_extended.csv
@@ -1,0 +1,2 @@
+run,sent,received,collisions,energy_J,throughput_bps,sf7,sf8,sf9,sf10,sf11,sf12,collisions_sf7,collisions_sf8,collisions_sf9,collisions_sf10,collisions_sf11,collisions_sf12
+1,2,2,0,0.022404,104.692309,2,0,0,0,0,0,0,0,0,0,0,0

--- a/simulateur_lora_sfrd_4.0/tests/test_flora_comparison.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_flora_comparison.py
@@ -10,10 +10,13 @@ sys.path.insert(0, str(ROOT))
 
 from VERSION_4.launcher.channel import Channel  # noqa: E402
 from VERSION_4.launcher.simulator import Simulator  # noqa: E402
-from VERSION_4.launcher.compare_flora import load_flora_metrics, compare_with_sim  # noqa: E402
+from VERSION_4.launcher.compare_flora import (
+    load_flora_metrics,
+    compare_with_sim,
+)  # noqa: E402
 
 
-def _make_sim(num_nodes: int) -> Simulator:
+def _make_sim(num_nodes: int, *, same_start: bool = False) -> Simulator:
     ch = Channel(shadowing_std=0)
     sim = Simulator(
         num_nodes=num_nodes,
@@ -35,7 +38,7 @@ def _make_sim(num_nodes: int) -> Simulator:
     sim.event_queue.clear()
     sim.event_id_counter = 0
     for idx, node in enumerate(sim.nodes):
-        sim.schedule_event(node, idx * 1.0)
+        sim.schedule_event(node, 0.0 if same_start else idx * 1.0)
     return sim
 
 
@@ -47,3 +50,48 @@ def test_compare_with_flora_sample():
     flora_metrics = load_flora_metrics(flora_csv)
     assert metrics["PDR"] == pytest.approx(flora_metrics["PDR"])
     assert compare_with_sim(metrics, flora_csv)
+
+
+def _add_collision_distribution(sim: Simulator, metrics: dict) -> None:
+    """Helper to compute the collision distribution per SF."""
+    coll_dist = {}
+    for sf in range(7, 13):
+        coll_dist[sf] = sum(
+            n.packets_collision for n in sim.nodes if n.sf == sf
+        )
+    metrics["collisions_distribution"] = coll_dist
+
+
+def test_compare_with_extended_metrics():
+    sim = _make_sim(num_nodes=2)
+    sim.run()
+    metrics = sim.get_metrics()
+    _add_collision_distribution(sim, metrics)
+    flora_csv = Path(__file__).parent / "data" / "flora_extended.csv"
+    flora_metrics = load_flora_metrics(flora_csv)
+    assert metrics["throughput_bps"] == pytest.approx(
+        flora_metrics["throughput_bps"]
+    )
+    assert metrics["energy_J"] == pytest.approx(flora_metrics["energy_J"])
+    assert compare_with_sim(
+        metrics,
+        flora_csv,
+        pdr_tol=1e-6,
+        throughput_tol=1e-6,
+        energy_tol=1e-6,
+    )
+
+
+def test_compare_with_collision_metrics():
+    sim = _make_sim(num_nodes=3, same_start=True)
+    sim.run()
+    metrics = sim.get_metrics()
+    _add_collision_distribution(sim, metrics)
+    flora_csv = Path(__file__).parent / "data" / "flora_collision.csv"
+    assert compare_with_sim(
+        metrics,
+        flora_csv,
+        pdr_tol=1e-6,
+        throughput_tol=1e-6,
+        energy_tol=1e-6,
+    )


### PR DESCRIPTION
## Summary
- enrichir `compare_flora.py` avec le débit, l'énergie et la répartition des collisions
- ajouter deux exports FLoRa d'exemple
- couvrir les nouveaux cas dans `test_flora_comparison`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687963a0be408331b03d92d636eaa0eb