### PR TITLE
Fix docstring indentation causing IndentationError

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/compare_flora.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/compare_flora.py
@@ -9,21 +9,21 @@ import pandas as pd
 
 
 def load_flora_metrics(csv_path: str | Path) -> dict[str, Any]:
-"""Return metrics from a FLoRa CSV export.
+    """Return metrics from a FLoRa CSV export.
 
-The file is expected to contain at least the columns ``sent`` and ``received``
-to compute the PDR as well as ``sfX`` columns describing the spreading factor
-distribution.  Additional optional columns may be present:
+    The file is expected to contain at least the columns ``sent`` and ``received``
+    to compute the PDR as well as ``sfX`` columns describing the spreading factor
+    distribution.  Additional optional columns may be present:
 
-``throughput_bps``
-    Average throughput in bits per second.
-``energy`` or ``energy_J``
-    Energy consumption for the run.
-``collisions``
-    Total number of packet collisions.
-``collisions_sfX``
-    Number of collisions that occurred with spreading factor ``X``.
-"""
+    ``throughput_bps``
+        Average throughput in bits per second.
+    ``energy`` or ``energy_J``
+        Energy consumption for the run.
+    ``collisions``
+        Total number of packet collisions.
+    ``collisions_sfX``
+        Number of collisions that occurred with spreading factor ``X``.
+    """
     df = pd.read_csv(csv_path)
     total_sent = int(df["sent"].sum()) if "sent" in df.columns else 0
     total_recv = int(df["received"].sum()) if "received" in df.columns else 0


### PR DESCRIPTION
## Summary
- correct the indentation of the docstring in `compare_flora.py`
- ensure all tests still pass

## Testing
- `pytest tests/test_run_script.py tests/test_scheduler.py -q`
- `pytest tests/test_flora_comparison.py -q` *(skipped: pandas not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68797801c170833189975799619f29f0