### PR TITLE
Read extra FLoRa metrics

### DIFF
--- a/simulateur_lora_sfrd_4.0/README.md
+++ b/simulateur_lora_sfrd_4.0/README.md
@@ -137,11 +137,12 @@ The tests compare RSSI and airtime calculations against theoretical values and c
 ### Cross-check with FLoRa
 
 The module `VERSION_4/launcher/compare_flora.py` reads CSV exports from
-the FLoRa simulator and extracts the Packet Delivery Ratio and the
-spreading factor histogram. The test file
-`tests/test_flora_comparison.py` demonstrates how to compare these
-values with those returned by `Simulator.get_metrics` to validate the
-Python implementation against OMNeT++ runs.
+the FLoRa simulator and extracts several metrics: Packet Delivery Ratio,
+spreading factor histogram, energy consumption, throughput and packet
+collisions.  The test file `tests/test_flora_comparison.py` demonstrates
+how to compare these values with those returned by
+`Simulator.get_metrics` to validate the Python implementation against
+OMNeT++ runs.
 You can also supply a reference CSV to `examples/run_flora_example.py` via
 `--flora-csv` to perform this check outside the test suite.
 

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/compare_flora.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/compare_flora.py
@@ -39,6 +39,8 @@ def load_flora_metrics(csv_path: str | Path) -> dict[str, Any]:
     else:
         energy = 0.0
 
+    collisions = int(df["collisions"].sum()) if "collisions" in df.columns else 0
+
     collision_cols = [c for c in df.columns if c.startswith("collisions_sf")]
     collision_dist = {int(c.split("sf")[1]): int(df[c].sum()) for c in collision_cols}
 
@@ -48,6 +50,7 @@ def load_flora_metrics(csv_path: str | Path) -> dict[str, Any]:
         "throughput_bps": throughput,
         "energy_J": energy,
         "collision_distribution": collision_dist,
+        "collisions": collisions,
     }
 
 

--- a/simulateur_lora_sfrd_4.0/tests/test_flora_comparison.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_flora_comparison.py
@@ -74,6 +74,7 @@ def test_compare_with_flora_sample():
     assert metrics["PDR"] == pytest.approx(flora_metrics["PDR"])
     assert metrics["throughput_bps"] == pytest.approx(flora_metrics["throughput_bps"], rel=1e-3)
     assert metrics["energy_J"] == pytest.approx(flora_metrics["energy_J"], rel=1e-3)
+    assert metrics["collisions"] == flora_metrics["collisions"]
     assert compare_with_sim(metrics, flora_csv)
 
     sim_cd = {7: sum(n.packets_collision for n in sim.nodes if n.sf == 7)}
@@ -87,5 +88,6 @@ def test_collision_distribution_against_flora():
     flora_csv = Path(__file__).parent / "data" / "flora_collisions.csv"
     flora_metrics = load_flora_metrics(flora_csv)
     sim_cd = {7: sum(n.packets_collision for n in sim.nodes if n.sf == 7)}
+    assert sim.packets_lost_collision == flora_metrics["collisions"]
     assert sim.packets_lost_collision == sum(flora_metrics["collision_distribution"].values())
     assert sim_cd == flora_metrics["collision_distribution"]


### PR DESCRIPTION
## Summary
- parse collision count from FLoRa CSV metrics
- assert collision count equality in tests
- document the extra metrics in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879ddf06ee48331a3c7014cb2e7959d