### PR TITLE
Add tests for AdvancedChannel and NetworkServer

### DIFF
--- a/simulateur_lora_sfrd_4.0/tests/test_advanced_channel.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_advanced_channel.py
@@ -5,6 +5,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 from VERSION_4.launcher.advanced_channel import AdvancedChannel  # noqa: E402
+import random
 
 
 def test_cost231_path_loss_vs_log_distance():
@@ -40,3 +41,11 @@ def test_rician_fading_variability():
     r1, _ = adv.compute_rssi(14.0, 100.0)
     r2, _ = adv.compute_rssi(14.0, 100.0)
     assert r1 != r2
+
+
+def test_variable_noise_changes_snr():
+    random.seed(0)
+    adv = AdvancedChannel(fading="", shadowing_std=0, variable_noise_std=5.0)
+    _, snr1 = adv.compute_rssi(14.0, 100.0)
+    _, snr2 = adv.compute_rssi(14.0, 100.0)
+    assert snr1 != snr2

--- a/simulateur_lora_sfrd_4.0/tests/test_server.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_server.py
@@ -1,0 +1,46 @@
+import sys
+from pathlib import Path
+import random
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from VERSION_4.launcher.node import Node  # noqa: E402
+from VERSION_4.launcher.gateway import Gateway  # noqa: E402
+from VERSION_4.launcher.channel import Channel  # noqa: E402
+from VERSION_4.launcher.server import NetworkServer  # noqa: E402
+from VERSION_4.launcher.lorawan import LoRaWANFrame, JoinAccept  # noqa: E402
+
+
+def test_send_downlink_immediate():
+    node = Node(1, 0.0, 0.0, 7, 14.0, channel=Channel(shadowing_std=0))
+    gw = Gateway(1, 0.0, 0.0)
+    ns = NetworkServer()
+    ns.gateways = [gw]
+    ns.nodes = [node]
+
+    ns.send_downlink(node, b"data", confirmed=True, request_ack=True)
+    frame = gw.pop_downlink(node.id)
+    assert isinstance(frame, LoRaWANFrame)
+    assert frame.confirmed
+    assert frame.fctrl == 0x20
+    assert node.fcnt_down == 1
+    assert node.downlink_pending == 1
+
+
+def test_receive_triggers_otaa_activation():
+    random.seed(0)
+    node = Node(2, 0.0, 0.0, 7, 14.0, channel=Channel(shadowing_std=0), activated=False, appkey=bytes(16))
+    gw = Gateway(2, 0.0, 0.0)
+    ns = NetworkServer()
+    ns.gateways = [gw]
+    ns.nodes = [node]
+    ns.channel = Channel(shadowing_std=0)
+
+    ns.receive(event_id=1, node_id=node.id, gateway_id=gw.id, rssi=-120)
+    frame = gw.pop_downlink(node.id)
+    assert isinstance(frame, JoinAccept)
+    assert len(node.nwkskey) == 16
+    assert len(node.appskey) == 16
+    assert ns.next_devaddr == 2
+    assert node.fcnt_down == 1


### PR DESCRIPTION
## Summary
- extend advanced channel tests to cover variable noise
- add new server tests for downlink and OTAA activation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6879fb835fa083318770ac56c94ce985