### PR TITLE
Add OMNeT++ PHY option

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/__init__.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/__init__.py
@@ -11,6 +11,7 @@ from .smooth_mobility import SmoothMobility
 from .lorawan import LoRaWANFrame, compute_rx1, compute_rx2
 from .downlink_scheduler import DownlinkScheduler
 from .omnet_model import OmnetModel
+from .omnet_phy import OmnetPHY
 
 __all__ = [
     "Node",
@@ -27,6 +28,7 @@ __all__ = [
     "compute_rx2",
     "DownlinkScheduler",
     "OmnetModel",
+    "OmnetPHY",
 ]
 
 for name in __all__:

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/gateway.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/gateway.py
@@ -91,7 +91,7 @@ class Gateway:
 
         # Sinon, on a une collision potentielle: déterminer le capture effect
         # Tri décroissant selon la puissance ou le SNR
-        if capture_mode == "advanced" and noise_floor is not None:
+        if capture_mode in {"advanced", "omnet"} and noise_floor is not None:
             snrs = [t['rssi'] - noise_floor for t in colliders]
             indices = sorted(range(len(colliders)), key=lambda i: snrs[i], reverse=True)
             strongest = colliders[indices[0]]

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/omnet_phy.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/omnet_phy.py
@@ -1,0 +1,79 @@
+"""Simplified OMNeT++ physical layer helpers."""
+
+from __future__ import annotations
+
+import math
+import random
+
+from .omnet_model import OmnetModel
+
+
+class OmnetPHY:
+    """Replicate OMNeT++ FLoRa PHY calculations."""
+
+    def __init__(self, channel) -> None:
+        self.channel = channel
+        self.model = OmnetModel(
+            channel.fine_fading_std,
+            channel.omnet.correlation,
+            channel.omnet.noise_std,
+        )
+
+    # ------------------------------------------------------------------
+    def path_loss(self, distance: float) -> float:
+        """Return path loss in dB using the log distance model."""
+        if distance <= 0:
+            return 0.0
+        freq_mhz = self.channel.frequency_hz / 1e6
+        pl_d0 = 32.45 + 20 * math.log10(freq_mhz) - 60.0
+        loss = pl_d0 + 10 * self.channel.path_loss_exp * math.log10(max(distance, 1.0))
+        return loss + self.channel.system_loss_dB
+
+    def noise_floor(self) -> float:
+        """Return the noise floor (dBm) including optional variations."""
+        ch = self.channel
+        thermal = ch.receiver_noise_floor_dBm + 10 * math.log10(ch.bandwidth)
+        noise = thermal + ch.noise_figure_dB + ch.interference_dB
+        if ch.noise_floor_std > 0:
+            noise += random.gauss(0.0, ch.noise_floor_std)
+        noise += self.model.noise_variation()
+        return noise
+
+    def compute_rssi(self, tx_power_dBm: float, distance: float, sf: int | None = None) -> tuple[float, float]:
+        ch = self.channel
+        loss = self.path_loss(distance)
+        if ch.shadowing_std > 0:
+            loss += random.gauss(0.0, ch.shadowing_std)
+        rssi = (
+            tx_power_dBm
+            + ch.tx_antenna_gain_dB
+            + ch.rx_antenna_gain_dB
+            - loss
+            - ch.cable_loss_dB
+        )
+        if ch.tx_power_std > 0:
+            rssi += random.gauss(0.0, ch.tx_power_std)
+        if ch.fast_fading_std > 0:
+            rssi += random.gauss(0.0, ch.fast_fading_std)
+        if ch.time_variation_std > 0:
+            rssi += random.gauss(0.0, ch.time_variation_std)
+        rssi += self.model.fine_fading()
+        rssi += ch.rssi_offset_dB
+        snr = rssi - self.noise_floor() + ch.snr_offset_dB
+        if sf is not None:
+            snr += 10 * math.log10(2 ** sf)
+        return rssi, snr
+
+    def capture(self, rssi_list: list[float]) -> list[bool]:
+        """Return list of booleans indicating which signals are captured."""
+        if not rssi_list:
+            return []
+        order = sorted(range(len(rssi_list)), key=lambda i: rssi_list[i], reverse=True)
+        winners = [False] * len(rssi_list)
+        if len(order) == 1:
+            winners[order[0]] = True
+            return winners
+        if rssi_list[order[0]] - rssi_list[order[1]] >= self.channel.capture_threshold_dB:
+            winners[order[0]] = True
+        return winners
+

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/simulator.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/simulator.py
@@ -62,7 +62,8 @@ class Simulator:
                  min_interference_time: float = 0.0,
                  config_file: str | None = None,
                  seed: int | None = None,
-                 class_c_rx_interval: float = 1.0):
+                 class_c_rx_interval: float = 1.0,
+                 phy_model: str = ""):
         """
         Initialise la simulation LoRa avec les entités et paramètres donnés.
         :param num_nodes: Nombre de nœuds à simuler.
@@ -100,6 +101,7 @@ class Simulator:
             exécution.
         :param class_c_rx_interval: Période entre deux vérifications de
             downlink pour les nœuds de classe C (s).
+        :param phy_model: "omnet" pour activer le modèle physique OMNeT++.
         """
         # Paramètres de simulation
         self.num_nodes = num_nodes
@@ -118,6 +120,7 @@ class Simulator:
         self.detection_threshold_dBm = detection_threshold_dBm
         self.min_interference_time = min_interference_time
         self.config_file = config_file
+        self.phy_model = phy_model
         # Activation ou non de la mobilité des nœuds
         self.mobility_enabled = mobility
         self.mobility_model = SmoothMobility(area_size, mobility_speed[0], mobility_speed[1])
@@ -139,7 +142,7 @@ class Simulator:
                     ch.detection_threshold_dBm = detection_threshold_dBm
         else:
             if channels is None:
-                ch_list = [Channel(detection_threshold_dBm=detection_threshold_dBm)]
+                ch_list = [Channel(detection_threshold_dBm=detection_threshold_dBm, phy_model=phy_model)]
             else:
                 ch_list = []
                 for ch in channels:
@@ -149,7 +152,7 @@ class Simulator:
                         ch_list.append(ch)
                     else:
                         ch_list.append(
-                            Channel(frequency_hz=float(ch), detection_threshold_dBm=detection_threshold_dBm)
+                            Channel(frequency_hz=float(ch), detection_threshold_dBm=detection_threshold_dBm, phy_model=phy_model)
                         )
             self.multichannel = MultiChannel(ch_list, method=channel_distribution)
 
@@ -396,7 +399,10 @@ class Simulator:
                     node.channel.frequency_hz,
                     self.min_interference_time,
                     noise_floor=node.channel.noise_floor_dBm(),
-                    capture_mode="advanced" if node.channel.advanced_capture else "basic",
+                    capture_mode=(
+                        "omnet" if node.channel.phy_model == "omnet"
+                        else ("advanced" if node.channel.advanced_capture else "basic")
+                    ),
                 )
 
             # Retenir le meilleur RSSI/SNR mesuré pour cette transmission

--- a/simulateur_lora_sfrd_4.0/tests/test_omnet_phy.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_omnet_phy.py
@@ -1,0 +1,61 @@
+import sys
+import random
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pandas")
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from VERSION_4.launcher.channel import Channel  # noqa: E402
+from VERSION_4.launcher.simulator import Simulator  # noqa: E402
+from VERSION_4.launcher.compare_flora import load_flora_rx_stats  # noqa: E402
+
+
+def _make_colliding_sim() -> Simulator:
+    ch = Channel(
+        shadowing_std=0,
+        fast_fading_std=0,
+        fine_fading_std=1.0,
+        variable_noise_std=0.5,
+        phy_model="omnet",
+    )
+    sim = Simulator(
+        num_nodes=2,
+        num_gateways=1,
+        area_size=10.0,
+        transmission_mode="Periodic",
+        packet_interval=10.0,
+        packets_to_send=2,
+        mobility=False,
+        duty_cycle=None,
+        channels=[ch],
+        fixed_sf=7,
+        fixed_tx_power=14.0,
+        phy_model="omnet",
+    )
+    gw = sim.gateways[0]
+    for node in sim.nodes:
+        node.x = gw.x
+        node.y = gw.y
+    sim.event_queue.clear()
+    sim.event_id_counter = 0
+    for node in sim.nodes:
+        sim.schedule_event(node, 0.0)
+    return sim
+
+
+def test_omnet_phy_matches_flora():
+    random.seed(0)
+    sim = _make_colliding_sim()
+    while sim.step():
+        pass
+    rssi = sim.nodes[0].last_rssi
+    snr = sim.nodes[0].last_snr
+    flora_csv = Path(__file__).parent / "data" / "flora_rx_stats.csv"
+    flora = load_flora_rx_stats(flora_csv)
+    assert rssi == pytest.approx(flora["rssi"], abs=1e-3)
+    assert snr == pytest.approx(flora["snr"], abs=1e-3)
+    assert sim.packets_lost_collision == flora["collisions"]


### PR DESCRIPTION
## Summary
- implement `OmnetPHY` helper for OMNeT++ propagation
- support `phy_model="omnet"` in `Channel` and `Simulator`
- update capture logic for the new model
- provide regression test comparing with FLoRa reference data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687a08cd797c8331b117ec3e1875150b