### PR TITLE
Handle beacon parameters and add downlink tests

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/README.md
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/README.md
@@ -119,6 +119,9 @@ scénarios FLoRa. Voici la liste complète des options :
 - `config_file` : chemin d'un INI décrivant positions, SF et puissance.
 - `seed` : graine aléatoire pour reproduire le placement.
 - `class_c_rx_interval` : période de vérification des downlinks en classe C.
+- `beacon_interval` : durée séparant deux beacons pour la classe B (s).
+- `ping_slot_interval` : intervalle de base entre ping slots successifs (s).
+- `ping_slot_offset` : délai après le beacon avant le premier ping slot (s).
 
 ## Paramètres radio avancés
 


### PR DESCRIPTION
## Summary
- document beacon and ping slot parameters in README
- test downlink delivery via beacon ping slots for Class B
- test Class C downlink right after an uplink

## Testing
- `pytest -q tests/test_downlink_bc.py::test_class_b_downlink_buffer_delivery tests/test_downlink_bc.py::test_class_c_downlink_after_tx_window`

------
https://chatgpt.com/codex/tasks/task_e_687a08c89e98833185faf9fb9566c0d9