### PR TITLE
Enhance visualization and config support

### DIFF
--- a/simulateur_lora_sfrd_4.0/README.md
+++ b/simulateur_lora_sfrd_4.0/README.md
@@ -97,7 +97,9 @@ in `examples/` (`flora_full.csv`, `flora_collisions.csv`, etc.) to help check
 your results.
 
 Any INI file must define ``[gateways]`` and ``[nodes]`` sections listing the
-coordinates (and optionally SF and power) of each entity.
+coordinates (and optionally SF and power) of each entity.  The loader also
+accepts a JSON document containing ``gateways`` and ``nodes`` lists to
+describe more complex scenarios.
 
 Use a preset propagation environment from Python:
 

--- a/simulateur_lora_sfrd_4.0/VERSION_4/README.md
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/README.md
@@ -116,7 +116,8 @@ scénarios FLoRa. Voici la liste complète des options :
 - `detection_threshold_dBm` : RSSI minimal pour qu'une réception soit valide.
 - `min_interference_time` : durée de chevauchement minimale pour déclarer une
   collision (s).
-- `config_file` : chemin d'un INI décrivant positions, SF et puissance.
+- `config_file` : chemin d'un fichier INI ou JSON décrivant
+  positions, SF et puissance.
 - `seed` : graine aléatoire pour reproduire le placement.
 - `class_c_rx_interval` : période de vérification des downlinks en classe C.
 - `beacon_interval` : durée séparant deux beacons pour la classe B (s).

--- a/simulateur_lora_sfrd_4.0/tests/test_config_loader.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_config_loader.py
@@ -26,3 +26,17 @@ def test_load_config_parses_nodes_and_gateways(tmp_path):
     assert len(sim.gateways) == 1
     assert sim.nodes[0].x == 1
     assert sim.nodes[0].sf == 7
+
+
+def test_load_config_supports_json(tmp_path):
+    cfg = tmp_path / "scenario.json"
+    cfg.write_text(
+        '{"gateways": [{"x": 0, "y": 0}], "nodes": [{"x": 1, "y": 2, "sf": 9}]}'
+    )
+
+    nodes, gws = load_config(cfg)
+    assert len(gws) == 1 and gws[0]["y"] == 0
+    assert len(nodes) == 1 and nodes[0]["sf"] == 9
+
+    sim = Simulator(config_file=str(cfg))
+    assert len(sim.nodes) == 1 and sim.nodes[0].x == 1


### PR DESCRIPTION
## Summary
- add timeline plot to dashboard and display last transmissions on map
- support JSON format in `load_config`
- document JSON configurations in README
- test JSON config loader

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a0e277b088331b023341c4dd62b3c