### PR TITLE
Implement partial collision modeling with timing and frequency offsets

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/channel.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/channel.py
@@ -195,7 +195,13 @@ class Channel:
         return pl + self.system_loss_dB
 
     def compute_rssi(
-        self, tx_power_dBm: float, distance: float, sf: int | None = None
+        self,
+        tx_power_dBm: float,
+        distance: float,
+        sf: int | None = None,
+        *,
+        freq_offset_hz: float | None = None,
+        sync_offset_s: float | None = None,
     ) -> tuple[float, float]:
         """Calcule le RSSI et le SNR attendus à une certaine distance.
 

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/omnet_phy.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/omnet_phy.py
@@ -39,7 +39,15 @@ class OmnetPHY:
         noise += self.model.noise_variation()
         return noise
 
-    def compute_rssi(self, tx_power_dBm: float, distance: float, sf: int | None = None) -> tuple[float, float]:
+    def compute_rssi(
+        self,
+        tx_power_dBm: float,
+        distance: float,
+        sf: int | None = None,
+        *,
+        freq_offset_hz: float | None = None,
+        sync_offset_s: float | None = None,
+    ) -> tuple[float, float]:
         ch = self.channel
         loss = self.path_loss(distance)
         if ch.shadowing_std > 0:


### PR DESCRIPTION
## Summary
- extend Node to generate correlated timing and frequency offsets
- accept new offset parameters in Channel and OmnetPHY
- compute offsets in Simulator and forward to Gateway
- apply pairwise interference penalty in Gateway to emulate partial collisions
- import math in Gateway

## Testing
- `pytest -q`
- `pytest tests/test_simulator.py::test_simulator_step_collision -q`

------
https://chatgpt.com/codex/tasks/task_e_687a0dd962588331ad842553c9e16502