### PR TITLE
Add multi-dataset calibration

### DIFF
--- a/simulateur_lora_sfrd_4.0/README.md
+++ b/simulateur_lora_sfrd_4.0/README.md
@@ -180,6 +180,17 @@ The resulting parameters typically give a correspondence above **99 %** with
 FLoRa on the provided dataset. The calibration is also executed during the
 test suite to ensure the simulator stays in sync with the reference model.
 
+To check several FLoRa exports at once and average the error over all of them
+use:
+
+```bash
+python tools/calibrate_flora.py examples/flora_full.csv examples/flora_interference.csv
+```
+
+In this cross-validation mode the script evaluates the Packet Delivery Ratio
+and spreading factor histograms across all inputs to pick the most consistent
+propagation parameters.
+
 ## Versioning
 
 The current package version is defined in `pyproject.toml`.

--- a/simulateur_lora_sfrd_4.0/tests/test_cross_validate.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_cross_validate.py
@@ -1,0 +1,18 @@
+import sys
+from pathlib import Path
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+pytest.importorskip("pandas")
+
+from tools.calibrate_flora import cross_validate
+
+
+def test_cross_validate_multi():
+    csv1 = Path(__file__).parent / "data" / "flora_sample.csv"
+    csv2 = Path(__file__).parent / "data" / "flora_full.csv"
+    params, err = cross_validate([csv1, csv2], runs=1, path_loss_values=(2.7,), shadowing_values=(6.0,), seed=0)
+    assert params is not None
+    assert err >= 0.0

--- a/simulateur_lora_sfrd_4.0/tools/calibrate_flora.py
+++ b/simulateur_lora_sfrd_4.0/tools/calibrate_flora.py
@@ -91,13 +91,55 @@ def calibrate(
     return best_params, best_err
 
 
+def cross_validate(
+    flora_csvs: list[str | Path],
+    runs: int = 3,
+    path_loss_values: tuple[float, ...] = (2.5, 2.7, 2.9),
+    shadowing_values: tuple[float, ...] = (2.0, 4.0, 6.0),
+    *,
+    seed: int | None = None,
+) -> tuple[dict[str, float] | None, float]:
+    """Return best parameters averaged over multiple datasets."""
+    refs = [load_flora_metrics(p) for p in flora_csvs]
+    best_err = math.inf
+    best_params: dict[str, float] | None = None
+    for pl in path_loss_values:
+        for sh in shadowing_values:
+            err = 0.0
+            for flora in refs:
+                m = _run_sim(pl, sh, runs, seed)
+                pdr_diff = abs(m.get("PDR", 0.0) - flora.get("PDR", 0.0))
+                sim_sf = m.get("sf_distribution", {})
+                flora_sf = flora.get("sf_distribution", {})
+                all_sf = set(sim_sf) | set(flora_sf)
+                sf_diff = sum(abs(sim_sf.get(sf, 0) - flora_sf.get(sf, 0)) for sf in all_sf)
+                norm = max(sum(flora_sf.values()), 1)
+                err += pdr_diff + sf_diff / norm
+            err /= len(refs)
+            if err < best_err:
+                best_err = err
+                best_params = {"path_loss_exp": pl, "shadowing_std": sh}
+    if best_params:
+        print(f"Best parameters: {best_params} (avg error {best_err:.4f})")
+    return best_params, best_err
+
+
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Calibrate simulator using a FLoRa CSV reference")
-    parser.add_argument("flora_csv", help="CSV exported from FLoRa")
+    parser = argparse.ArgumentParser(
+        description="Calibrate simulator using one or more FLoRa CSV references"
+    )
+    parser.add_argument(
+        "flora_csv",
+        nargs="+",
+        help="CSV exported from FLoRa (can provide several for cross-validation)",
+    )
     parser.add_argument("--runs", type=int, default=3, help="Runs per parameter set")
     parser.add_argument("--seed", type=int, help="Base random seed")
     args = parser.parse_args()
-    calibrate(Path(args.flora_csv), runs=args.runs, seed=args.seed)
+    if len(args.flora_csv) == 1:
+        calibrate(Path(args.flora_csv[0]), runs=args.runs, seed=args.seed)
+    else:
+        cross_validate([Path(p) for p in args.flora_csv], runs=args.runs, seed=args.seed)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend `calibrate_flora.py` with `cross_validate` for multiple FLoRa CSVs
- update CLI to accept several reference files
- mention cross validation in the README
- test new function with sample CSVs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a0e4f303c833196aa6e67ceadeb3b