### PR TITLE
Update docs with class B/C examples and limitations

### DIFF
--- a/simulateur_lora_sfrd_4.0/README.md
+++ b/simulateur_lora_sfrd_4.0/README.md
@@ -75,6 +75,38 @@ python VERSION_4/run.py --nodes 50 --gateways 2 --channels 3 \
 python VERSION_4/run.py --lorawan-demo --steps 100 --output lorawan.csv
 ```
 
+### LoRaWAN class B/C examples
+
+The Python API exposes additional parameters to experiment with class B or
+class C behaviours. Below are minimal code snippets:
+
+```python
+from launcher import Simulator
+
+# Class B nodes with periodic ping slots
+sim_b = Simulator(num_nodes=10, node_class="B", beacon_interval=128,
+                  ping_slot_interval=1.0)
+sim_b.run(1000)
+
+# Class C nodes listening almost continuously
+sim_c = Simulator(num_nodes=5, node_class="C", class_c_rx_interval=0.5)
+sim_c.run(500)
+
+```
+
+### Realistic mobility scenario
+
+You can model smoother movements by enabling mobility and adjusting the speed
+range:
+
+```python
+from launcher import Simulator
+
+sim = Simulator(num_nodes=20, gateways=3, area_size=2000.0, mobility=True,
+                mobility_speed=(1.0, 5.0))
+sim.run(1000)
+```
+
 ### FLoRa INI scenario example
 
 To reproduce a typical FLoRa configuration and check the SF distribution per
@@ -185,3 +217,18 @@ test suite to ensure the simulator stays in sync with the reference model.
 The current package version is defined in `pyproject.toml`.
 See `CHANGELOG.md` for a summary of releases.
 This project is licensed under the [MIT License](LICENSE).
+
+## Current limitations
+
+This simulator aims to remain lightweight and therefore omits several advanced
+concepts:
+
+- The physical layer is greatly simplified and does not reproduce hardware
+  imperfections found in real devices.
+- Support for LoRaWAN classes B and C is functional but lacks extensive timing
+  drift or beacon loss handling.
+- Mobility relies on random Bezier paths without obstacles or terrain
+  constraints.
+- Security aspects (join server, encryption validation) are kept minimal.
+
+Contributions are welcome to improve these areas or add missing features.

--- a/simulateur_lora_sfrd_4.0/VERSION_4/README.md
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/README.md
@@ -47,6 +47,36 @@ python run.py --nodes 50 --gateways 2 --channels 3 \
 python run.py --lorawan-demo --steps 100 --output lorawan.csv
 ```
 
+### Exemples classes B et C
+
+Utilisez l'API Python pour tester les modes B et C :
+
+```python
+from launcher import Simulator
+
+# Nœuds en classe B avec slots réguliers
+sim_b = Simulator(num_nodes=10, node_class="B", beacon_interval=128,
+                  ping_slot_interval=1.0)
+sim_b.run(1000)
+
+# Nœuds en classe C à écoute quasi continue
+sim_c = Simulator(num_nodes=5, node_class="C", class_c_rx_interval=0.5)
+sim_c.run(500)
+
+```
+
+### Scénario de mobilité réaliste
+
+Les déplacements peuvent être rendus plus doux en ajustant la plage de vitesses :
+
+```python
+from launcher import Simulator
+
+sim = Simulator(num_nodes=20, num_gateways=3, area_size=2000.0, mobility=True,
+                mobility_speed=(1.0, 5.0))
+sim.run(1000)
+```
+
 ## Duty cycle
 
 Le simulateur applique par défaut un duty cycle de 1 % pour se rapprocher des
@@ -335,4 +365,21 @@ Les points suivants ont été intégrés au simulateur :
 - **PDR par nœud et par type de trafic.** Chaque nœud maintient l'historique de ses vingt dernières transmissions afin de calculer un taux de livraison global et récent. Ces valeurs sont visibles dans le tableau de bord et exportées dans un fichier `metrics_*.csv`.
 - **Historique glissant et indicateurs QoS.** Le simulateur calcule désormais le délai moyen de livraison ainsi que le nombre de retransmissions sur la période récente.
 - **Indicateurs supplémentaires.** La méthode `get_metrics()` retourne le PDR par SF, passerelle, classe et nœud. Le tableau de bord affiche un récapitulatif et l'export produit deux fichiers CSV : un pour les événements détaillés et un pour les métriques agrégées.
+
+## Limites actuelles
+
+Le simulateur reste volontairement léger et certaines fonctionnalités manquent
+encore de maturité :
+
+- La couche physique est simplifiée et n'imite pas parfaitement les comportements
+  réels des modems LoRa.
+- Les classes B et C sont gérées de manière basique : les pertes de beacon ou
+  la dérive temporelle ne sont pas simulées.
+- La mobilité s'appuie sur des trajets aléatoires sans prise en compte
+  d'obstacles ou de cartes géographiques.
+- Les aspects sécurité LoRaWAN (chiffrement complet, serveurs de jointure)
+  restent minimaux.
+
+Les contributions sont les bienvenues pour lever ces limitations ou proposer de
+nouvelles idées.
 


### PR DESCRIPTION
## Summary
- document class B/C use via Python API
- show realistic mobility setup
- describe current limitations for contributors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a0e62639083318698986349e48353