### PR TITLE
Add oscillator drift and misalignment options

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/omnet_model.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/omnet_model.py
@@ -7,14 +7,28 @@ import random
 
 
 class OmnetModel:
-    """Handle fine fading and variable thermal noise."""
+    """Handle fine fading, oscillator drift and thermal noise."""
 
-    def __init__(self, fading_std: float = 0.0, correlation: float = 0.9, noise_std: float = 0.0) -> None:
+    def __init__(
+        self,
+        fading_std: float = 0.0,
+        correlation: float = 0.9,
+        noise_std: float = 0.0,
+        *,
+        freq_drift_std: float = 0.0,
+        clock_drift_std: float = 0.0,
+        temperature_K: float = 290.0,
+    ) -> None:
         self.fading_std = fading_std
         self.correlation = correlation
         self.noise_std = noise_std
+        self.freq_drift_std = freq_drift_std
+        self.clock_drift_std = clock_drift_std
+        self.temperature_K = temperature_K
         self._fading = 0.0
         self._noise = 0.0
+        self._freq = 0.0
+        self._clock = 0.0
 
     def fine_fading(self) -> float:
         """Return a temporally correlated fading term (dB)."""
@@ -31,4 +45,26 @@ class OmnetModel:
         gaussian = random.gauss(0.0, self.noise_std)
         self._noise = self.correlation * self._noise + (1 - self.correlation) * gaussian
         return self._noise
+
+    def frequency_drift(self) -> float:
+        """Return a correlated frequency drift sample (Hz)."""
+        if self.freq_drift_std <= 0.0:
+            return 0.0
+        gaussian = random.gauss(0.0, self.freq_drift_std)
+        self._freq = self.correlation * self._freq + (1 - self.correlation) * gaussian
+        return self._freq
+
+    def clock_drift(self) -> float:
+        """Return a correlated clock drift sample (s)."""
+        if self.clock_drift_std <= 0.0:
+            return 0.0
+        gaussian = random.gauss(0.0, self.clock_drift_std)
+        self._clock = self.correlation * self._clock + (1 - self.correlation) * gaussian
+        return self._clock
+
+    def thermal_noise_dBm(self, bandwidth: float) -> float:
+        """Return the thermal noise level for the given bandwidth."""
+        k = 1.38064852e-23
+        noise_w = k * self.temperature_K * bandwidth
+        return 10 * math.log10(noise_w) + 30
 


### PR DESCRIPTION
## Summary
- extend `OmnetModel` with frequency/clock drift and thermal noise calculation
- add radio-imperfection parameters to `Channel` and account for alignment penalty
- update `OmnetPHY` to use new model values
- keep full test suite passing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a1701323c83319929461f4ccbc2a2