### PR TITLE
Add beacon drift support and gateway conflict handling

### DIFF
--- a/simulateur_lora_sfrd_4.0/tests/test_lorawan.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_lorawan.py
@@ -102,3 +102,17 @@ def test_beacon_freq_ans_roundtrip():
     parsed = BeaconFreqAns.from_bytes(data)
     assert parsed == ans
 
+
+def test_next_beacon_time_drift():
+    from VERSION_4.launcher.lorawan import next_beacon_time
+
+    t = next_beacon_time(0.1, 10.0, last_beacon=0.0, drift=0.1)
+    assert t == pytest.approx(11.0)
+
+
+def test_next_beacon_time_recover():
+    from VERSION_4.launcher.lorawan import next_beacon_time
+
+    t = next_beacon_time(35.0, 10.0, last_beacon=0.0, drift=0.0, loss_limit=2.0)
+    assert t == pytest.approx(40.0)
+

--- a/simulateur_lora_sfrd_4.0/tests/test_scheduler.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_scheduler.py
@@ -8,6 +8,7 @@ from VERSION_4.launcher.node import Node  # noqa: E402
 from VERSION_4.launcher.gateway import Gateway  # noqa: E402
 from VERSION_4.launcher.channel import Channel  # noqa: E402
 from VERSION_4.launcher.server import NetworkServer  # noqa: E402
+from VERSION_4.launcher.downlink_scheduler import DownlinkScheduler  # noqa: E402
 
 
 def test_scheduled_downlink_delivery():
@@ -41,3 +42,34 @@ def test_multiple_scheduled_frames():
     payloads = sorted(f.payload for f in frames if f is not None)
     assert payloads == [b"one", b"two"]
     assert gw.pop_downlink(node.id) is None
+
+
+def test_scheduler_conflict_resolution():
+    node1 = Node(1, 0.0, 0.0, 7, 14.0, channel=Channel())
+    node1.class_type = "B"
+    node2 = Node(2, 0.0, 0.0, 7, 14.0, channel=Channel())
+    node2.class_type = "B"
+    gw = Gateway(1, 0.0, 0.0)
+    sched = DownlinkScheduler()
+    from VERSION_4.launcher.lorawan import LoRaWANFrame
+
+    frame = LoRaWANFrame(mhdr=0x60, fctrl=0, fcnt=0, payload=b"a")
+    t1 = sched.schedule_class_b(
+        node1,
+        0.0,
+        frame,
+        gw,
+        128.0,
+        1.0,
+        2.0,
+    )
+    t2 = sched.schedule_class_b(
+        node2,
+        0.0,
+        frame,
+        gw,
+        128.0,
+        1.0,
+        2.0,
+    )
+    assert t2 > t1


### PR DESCRIPTION
## Summary
- implement beacon drift and resync logic in `lorawan.py`
- adjust ping slot computation for drift
- handle gateway busy periods in `DownlinkScheduler`
- test new drift and scheduler features

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a170705d08331832ad7a791dd762f