### PR TITLE
Fix README bullet formatting

### DIFF
--- a/simulateur_lora_sfrd_4.0/README.md
+++ b/simulateur_lora_sfrd_4.0/README.md
@@ -10,7 +10,8 @@ This repository contains a lightweight LoRa network simulator implemented in Pyt
 - Optional multipath fading with synchronised paths and external interference modeling
 - Antenna gains and cable losses for accurate link budgets
 - Optional LoRa spreading gain applied to SNR
-- Additional COST231 path loss, Okumura‑Hata model and 3D propagation via `AdvancedChannel`
+- Additional COST231 path loss, Okumura‑Hata model and 3D propagation via
+  `AdvancedChannel`
 - Terrain and weather based attenuation parameters
 - Time‑varying frequency and synchronisation offsets for realistic collisions
 - Configurable bandwidth and coding rate per channel


### PR DESCRIPTION
## Summary
- split AdvancedChannel bullet onto two lines so it renders correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a524bbc508331b4c4a46bbb27ae9d