### PR TITLE
Remove timeline and enlarge manual positions section

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/dashboard.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/dashboard.py
@@ -137,7 +137,7 @@ position_textarea = pn.widgets.TextAreaInput(
     name="Coordonnées",
     height=100,
     visible=False,
-    width=400,
+    width=650,
     css_classes=["coord-textarea"],
 )
 
@@ -985,9 +985,8 @@ center_col = pn.Column(
     heatmap_button,
     heatmap_pane,
     sf_hist_pane,
-    timeline_pane,
     pn.Row(
-        pn.Column(manual_pos_toggle, position_textarea, width=400),
+        pn.Column(manual_pos_toggle, position_textarea, width=650),
     ),
     sizing_mode="stretch_width",
 )


### PR DESCRIPTION
## Summary
- remove packet timeline from the dashboard layout
- enlarge the manual position input widget

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a60c6776c8331a7e9027583d16bac