### PR TITLE
Fix simulation fast-forward button

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/dashboard.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/dashboard.py
@@ -776,7 +776,8 @@ export_button.on_click(exporter_csv)
 
 # --- Bouton d'accélération ---
 def fast_forward(event=None):
-    global sim, sim_callback, chrono_callback, start_time, max_real_time, auto_fast_forward
+    global sim, sim_callback, chrono_callback, map_anim_callback
+    global start_time, max_real_time, auto_fast_forward
     doc = pn.state.curdoc
     if sim and sim.running:
         auto_fast_forward = True
@@ -795,6 +796,9 @@ def fast_forward(event=None):
         if sim_callback:
             sim_callback.stop()
             sim_callback = None
+        if map_anim_callback:
+            map_anim_callback.stop()
+            map_anim_callback = None
         if chrono_callback:
             chrono_callback.stop()
             chrono_callback = None


### PR DESCRIPTION
## Summary
- fix fast-forward button by stopping the map update callback

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a610e7d9483318dd6f5028929174a