### PR TITLE
Fix fast forward mobility freeze

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/README.md
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/README.md
@@ -113,6 +113,7 @@ aléatoire des fréquences entre les nœuds.
 
 Le tableau de bord permet maintenant de fixer une **durée réelle maximale** en secondes. Lorsque cette limite est atteinte, la simulation s'arrête automatiquement. Un bouton « Accélérer jusqu'à la fin » lance l'exécution rapide pour obtenir aussitôt les métriques finales.
 **Attention :** cette accélération ne fonctionne que si un nombre fini de paquets est défini. Si le champ *Nombre de paquets* vaut 0 (infini), la simulation ne se termine jamais et l'export reste impossible.
+Depuis la version 4.0.1, l'accélération désactive aussi la mobilité restante lorsque toutes les transmissions ont été envoyées afin d'éviter un blocage du simulateur.
 
 ## Suivi de batterie
 

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/simulator.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/simulator.py
@@ -585,6 +585,10 @@ class Simulator:
                             new_queue.append(evt)
                     heapq.heapify(new_queue)
                     self.event_queue = new_queue
+                    # Stop scheduling further mobility events once every node
+                    # reached the packet limit to ensure the simulation
+                    # completes when using fast forward.
+                    self.mobility_enabled = False
                     logger.debug(
                         "Packet limit reached – no more new events will be scheduled."
                     )


### PR DESCRIPTION
## Summary
- avoid scheduling extra mobility after packet limit to prevent fast-forward freeze
- document the behaviour in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a724de8608331931e70b1afb43b96