### PR TITLE
Fix ADR1 to match standard settings

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/adr_standard_1.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/adr_standard_1.py
@@ -5,15 +5,15 @@ from .simulator import Simulator
 
 def apply(sim: Simulator) -> None:
     """Configure ADR variant adr_standard_1 (LoRaWAN defaults)."""
-    Simulator.MARGIN_DB = 50.0
+    Simulator.MARGIN_DB = 15.0
     sim.adr_node = False
     sim.adr_server = True
     sim.network_server.adr_enabled = True
     for node in sim.nodes:
         node.sf = 12
         node.initial_sf = 12
-        node.tx_power = 2.0
-        node.initial_tx_power = 2.0
+        node.tx_power = 14.0
+        node.initial_tx_power = 14.0
         node.adr_ack_cnt = 0
         node.adr_ack_limit = 64
         node.adr_ack_delay = 32


### PR DESCRIPTION
## Summary
- revert ADR1 margin and power to match LoRaWAN defaults

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687a78cd2a00833182ddaa3104af12e0