### PR TITLE
Fix example imports

### DIFF
--- a/simulateur_lora_sfrd_4.0/examples/run_flora_example.py
+++ b/simulateur_lora_sfrd_4.0/examples/run_flora_example.py
@@ -1,4 +1,10 @@
 import argparse
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
 from VERSION_4.launcher.simulator import Simulator
 from VERSION_4.launcher.adr_standard_1 import apply as adr1
 from VERSION_4.launcher.compare_flora import compare_with_sim


### PR DESCRIPTION
## Summary
- fix missing path setup in run_flora_example script

## Testing
- `pytest -q`
- `python examples/run_flora_example.py --runs 1` *(fails: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_687a7d9306a08331b762ff44f9ef159c