### PR TITLE
Update power mapping to FLoRa values

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/lorawan.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/lorawan.py
@@ -17,13 +17,14 @@ class LoRaWANFrame:
 
 DR_TO_SF = {0: 12, 1: 11, 2: 10, 3: 9, 4: 8, 5: 7}
 SF_TO_DR = {sf: dr for dr, sf in DR_TO_SF.items()}
+# Transmission power levels (matching the FLoRa reference values)
 TX_POWER_INDEX_TO_DBM = {
-    0: 20.0,
-    1: 17.0,
-    2: 14.0,
-    3: 11.0,
-    4: 8.0,
-    5: 5.0,
+    0: 14.0,
+    1: 12.0,
+    2: 10.0,
+    3: 8.0,
+    4: 6.0,
+    5: 4.0,
     6: 2.0,
 }
 DBM_TO_TX_POWER_INDEX = {int(v): k for k, v in TX_POWER_INDEX_TO_DBM.items()}

--- a/simulateur_lora_sfrd_4.0/tests/test_simulator.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_simulator.py
@@ -128,13 +128,13 @@ def test_lorawan_frame_handling():
     server = NetworkServer()
     server.gateways = [gw]
     server.nodes = [node]
-    server.send_downlink(node, b"", confirmed=True, adr_command=(9, 5.0), request_ack=True)
+    server.send_downlink(node, b"", confirmed=True, adr_command=(9, 4.0), request_ack=True)
 
     down = gw.pop_downlink(node.id)
     assert down is not None
     node.handle_downlink(down)
     assert node.sf == 9
-    assert node.tx_power == 5.0
+    assert node.tx_power == 4.0
     assert node.pending_mac_cmd == LinkADRAns().to_bytes()
     assert node.awaiting_ack is False
     assert node.need_downlink_ack


### PR DESCRIPTION
## Summary
- align `TX_POWER_INDEX_TO_DBM` with FLoRa mapping (index 0=14 dBm, etc.)
- keep reverse mapping in sync
- update simulator test checking ADR power level

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687acf66a2408331a050fc37eb494eab