### PR TITLE
Fix export button after fast-forward mode

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/dashboard.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/dashboard.py
@@ -647,7 +647,9 @@ def on_start(event):
 def on_stop(event):
     global sim, sim_callback, chrono_callback, map_anim_callback, start_time, max_real_time, paused
     global current_run, total_runs, runs_events, auto_fast_forward
-    if sim is None or not sim.running:
+    # If called programmatically (e.g. after fast_forward), allow cleanup even
+    # if the simulation has already stopped.
+    if sim is None or (event is not None and not sim.running):
         return
 
     sim.running = False


### PR DESCRIPTION
## Summary
- ensure `on_stop` activates export button even when called after fast-forward

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ad166a6188331bf54dad41985d438