### PR TITLE
Fix comment duplication in dashboard

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/dashboard.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/dashboard.py
@@ -478,7 +478,7 @@ def step_simulation():
         return
 
 
-# --- Bouton "Lancer la simulation" ---
+# --- Préparation de la simulation ---
 def setup_simulation(seed_offset: int = 0):
     """Crée et démarre un simulateur avec les paramètres du tableau de bord."""
     global sim, sim_callback, map_anim_callback, start_time, chrono_callback, elapsed_time, max_real_time, paused


### PR DESCRIPTION
## Summary
- clarify comment separating simulation setup and start callbacks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ad18105688331bf1e9aa0b2d3638f