### PR TITLE
Fix export button state when fast forwarding

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/dashboard.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/dashboard.py
@@ -724,7 +724,6 @@ def on_stop(event):
     pause_button.name = "Pause"
     pause_button.button_type = "primary"
     paused = False
-    export_button.disabled = False
 
     start_time = None
     max_real_time = None
@@ -751,6 +750,7 @@ def on_stop(event):
         pdr_table.object = table_df
         # Les tableaux détaillés ne sont plus mis à jour ici
     export_message.object = "✅ Simulation terminée. Tu peux exporter les résultats."
+    export_button.disabled = False
 
 
 # --- Export CSV local : Méthode universelle ---


### PR DESCRIPTION
## Summary
- enable export button once simulation finishes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ad1aa308c8331a1eee8afd84ba85e