### PR TITLE
Fix pause/resume state handling

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/dashboard.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/dashboard.py
@@ -859,11 +859,13 @@ fast_forward_button.on_click(fast_forward)
 
 # --- Bouton "Pause/Reprendre" ---
 def on_pause(event=None):
+    """Toggle simulation pause state safely."""
     global sim_callback, chrono_callback, start_time, elapsed_time, paused
     if sim is None or not sim.running:
         return
 
     if not paused:
+        # Pausing the simulation
         if sim_callback:
             sim_callback.stop()
             sim_callback = None
@@ -872,11 +874,14 @@ def on_pause(event=None):
             chrono_callback = None
         if start_time is not None:
             elapsed_time = time.time() - start_time
+        start_time = None  # Freeze chrono while paused
         pause_button.name = "Reprendre"
         pause_button.button_type = "success"
         paused = True
     else:
-        start_time = time.time() - elapsed_time
+        # Resuming the simulation
+        if start_time is None:
+            start_time = time.time() - elapsed_time
         if sim_callback is None:
             sim_callback = pn.state.add_periodic_callback(step_simulation, period=100, timeout=None)
         if chrono_callback is None:


### PR DESCRIPTION
## Summary
- improve the logic of the `on_pause` handler to keep time and button label consistent when pausing/resuming repeatedly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ad1be18e083318618b6013c9e8a49