### PR TITLE
Fix linter errors

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/server.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/server.py
@@ -1,5 +1,4 @@
 import logging
-import math
 from .downlink_scheduler import DownlinkScheduler
 
 logger = logging.getLogger(__name__)

--- a/simulateur_lora_sfrd_4.0/examples/run_flora_example.py
+++ b/simulateur_lora_sfrd_4.0/examples/run_flora_example.py
@@ -5,9 +5,9 @@ import sys
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from VERSION_4.launcher.simulator import Simulator
-from VERSION_4.launcher.adr_standard_1 import apply as adr1
-from VERSION_4.launcher.compare_flora import compare_with_sim
+from VERSION_4.launcher.simulator import Simulator  # noqa: E402
+from VERSION_4.launcher.adr_standard_1 import apply as adr1  # noqa: E402
+from VERSION_4.launcher.compare_flora import compare_with_sim  # noqa: E402
 
 NODE_POSITIONS = [
     (450.45, 490.0),

--- a/simulateur_lora_sfrd_4.0/tests/test_advanced_channel.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_advanced_channel.py
@@ -5,7 +5,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 from VERSION_4.launcher.advanced_channel import AdvancedChannel  # noqa: E402
-import random
+import random  # noqa: E402
 
 
 def test_cost231_path_loss_vs_log_distance():

--- a/simulateur_lora_sfrd_4.0/tests/test_calibrate_flora.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_calibrate_flora.py
@@ -7,7 +7,7 @@ sys.path.insert(0, str(ROOT))
 
 pytest.importorskip("pandas")
 
-from tools.calibrate_flora import calibrate
+from tools.calibrate_flora import calibrate  # noqa: E402
 
 
 def test_calibrate_flora_quick():

--- a/simulateur_lora_sfrd_4.0/tests/test_cross_validate.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_cross_validate.py
@@ -7,7 +7,7 @@ sys.path.insert(0, str(ROOT))
 
 pytest.importorskip("pandas")
 
-from tools.calibrate_flora import cross_validate
+from tools.calibrate_flora import cross_validate  # noqa: E402
 
 
 def test_cross_validate_multi():

--- a/simulateur_lora_sfrd_4.0/tests/test_downlink_bc.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_downlink_bc.py
@@ -35,7 +35,6 @@ def _make_sim(class_type: str) -> Simulator:
 def test_downlink_delivery_class_c():
     sim = _make_sim("C")
     node = sim.nodes[0]
-    gw = sim.gateways[0]
     sim.event_queue.clear()
     sim.event_id_counter = 0
     heapq.heappush(sim.event_queue, Event(0.0, EventType.RX_WINDOW, 0, node.id))
@@ -50,7 +49,6 @@ def test_downlink_delivery_class_c():
 def test_scheduler_programs_class_b_slot():
     sim = _make_sim("B")
     node = sim.nodes[0]
-    gw = sim.gateways[0]
     sim.event_queue.clear()
     sim.event_id_counter = 0
     heapq.heappush(sim.event_queue, Event(0.0, EventType.RX_WINDOW, 0, node.id))
@@ -62,7 +60,7 @@ def test_scheduler_programs_class_b_slot():
         node,
         0.0,
         frame,
-        gw,
+        sim.gateways[0],
         sim.beacon_interval,
         sim.ping_slot_interval,
         sim.ping_slot_offset,
@@ -79,7 +77,6 @@ def test_ping_slot_periodicity():
     sim = _make_sim("B")
     node = sim.nodes[0]
     node.ping_slot_periodicity = 1
-    gw = sim.gateways[0]
     sim.event_queue.clear()
     sim.event_id_counter = 0
     heapq.heappush(sim.event_queue, Event(0.0, EventType.RX_WINDOW, 0, node.id))
@@ -91,7 +88,7 @@ def test_ping_slot_periodicity():
         node,
         5.0,
         frame,
-        gw,
+        sim.gateways[0],
         sim.beacon_interval,
         sim.ping_slot_interval,
         sim.ping_slot_offset,
@@ -106,7 +103,6 @@ def test_ping_slot_periodicity():
 def test_class_c_continuous_rx():
     sim = _make_sim("C")
     node = sim.nodes[0]
-    gw = sim.gateways[0]
     sim.event_queue.clear()
     sim.event_id_counter = 0
     heapq.heappush(sim.event_queue, Event(0.0, EventType.RX_WINDOW, 0, node.id))
@@ -121,7 +117,6 @@ def test_class_c_continuous_rx():
 def test_class_b_downlink_buffer_delivery():
     sim = _make_sim("B")
     node = sim.nodes[0]
-    gw = sim.gateways[0]
     sim.event_queue.clear()
     sim.event_id_counter = 0
     heapq.heappush(sim.event_queue, Event(0.0, EventType.RX_WINDOW, 0, node.id))
@@ -138,7 +133,6 @@ def test_class_b_downlink_buffer_delivery():
 def test_class_c_downlink_after_tx_window():
     sim = _make_sim("C")
     node = sim.nodes[0]
-    gw = sim.gateways[0]
     sim.event_queue.clear()
     sim.event_id_counter = 0
     sim.schedule_event(node, 0.0)

--- a/simulateur_lora_sfrd_4.0/tools/calibrate_flora.py
+++ b/simulateur_lora_sfrd_4.0/tools/calibrate_flora.py
@@ -11,10 +11,10 @@ import math
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from VERSION_4.launcher.simulator import Simulator
-from VERSION_4.launcher.channel import Channel
-from VERSION_4.launcher.adr_standard_1 import apply as adr1
-from VERSION_4.launcher.compare_flora import load_flora_metrics
+from VERSION_4.launcher.simulator import Simulator  # noqa: E402
+from VERSION_4.launcher.channel import Channel  # noqa: E402
+from VERSION_4.launcher.adr_standard_1 import apply as adr1  # noqa: E402
+from VERSION_4.launcher.compare_flora import load_flora_metrics  # noqa: E402
 
 NODE_POSITIONS = [
     (450.45, 490.0),


### PR DESCRIPTION
## Summary
- clean up unused import in `server.py`
- silence E402 linter warnings by adding `# noqa` comments
- remove unused variable `gw` in `tests/test_downlink_bc`

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aea8b22508331b7dab31c46492036