### PR TITLE
Fix default channel for nodes

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/node.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/node.py
@@ -2,6 +2,7 @@
 import math
 
 from .energy_profiles import EnergyProfile, FLORA_PROFILE
+from .channel import Channel
 
 # Default energy profile used by all nodes (based on the FLoRa model)
 DEFAULT_ENERGY_PROFILE = FLORA_PROFILE
@@ -79,7 +80,9 @@ class Node:
         self.initial_tx_power = tx_power
         self.tx_power = tx_power
         # Canal radio attribué (peut être modifié par le simulateur)
-        self.channel = channel
+        # Utiliser un canal par défaut si aucun n'est fourni pour éviter
+        # des erreurs lors des calculs d'airtime ou de RSSI.
+        self.channel = channel or Channel()
         # Offsets de fréquence et de synchronisation (corrélés dans le temps)
         from .advanced_channel import _CorrelatedValue
         self._freq_offset = _CorrelatedValue(

--- a/simulateur_lora_sfrd_4.0/tests/test_node_defaults.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_node_defaults.py
@@ -1,0 +1,15 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from VERSION_4.launcher.node import Node  # noqa: E402
+
+
+def test_node_default_channel():
+    node = Node(1, 0.0, 0.0, 7, 14.0)
+    # A default Channel instance should be created
+    assert node.channel is not None
+    # The channel should provide airtime calculation without error
+    assert node.channel.airtime(7) > 0


### PR DESCRIPTION
## Summary
- create default Channel instance when no channel is supplied to Node
- add regression test verifying node initializes with default channel

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687aea9507508331991082e2bebf916f