### PR TITLE
Add degraded channel option for ADR1 preset

### DIFF
--- a/simulateur_lora_sfrd_4.0/README.md
+++ b/simulateur_lora_sfrd_4.0/README.md
@@ -125,6 +125,9 @@ official detection threshold, interference window and a ``flora`` propagation
   metrics with an official FLoRa export using `compare_with_sim`. FLoRa stores
   its results in `.sca` and `.vec` files. You may convert them to CSV with
   external tools if needed.
+Passing `--degrade` to the script will enable a very harsh channel to quickly
+lower the PDR by raising the noise, applying Rayleigh fading and extra path
+loss.
 
 An example configuration file named `examples/flora_full.ini` reproduces the
 official positions used by FLoRa. Load it with

--- a/simulateur_lora_sfrd_4.0/VERSION_4/README.md
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/README.md
@@ -293,7 +293,7 @@ paramètre `fast_fading_std` afin de simuler un canal multipath et utiliser
 
 To reproduce FLoRa INI scenarios:
 1. Pass `flora_mode=True` when creating the `Simulator` (or enable **Mode FLoRa complet**). This applies the official `-110 dBm` detection threshold and a `5 s` interference window.
-2. Apply the ADR1 algorithm with `from VERSION_4.launcher.adr_standard_1 import apply as adr1` then `adr1(sim)`. This preset now mirrors the ADR logic of the original FLoRa server (SNR history, margin and multi‑step adjustments).
+2. Apply the ADR1 algorithm with `from VERSION_4.launcher.adr_standard_1 import apply as adr1` then `adr1(sim)`. This preset now mirrors the ADR logic of the original FLoRa server (SNR history, margin and multi‑step adjustments). Passing `degrade_channel=True` enables a harsh propagation profile to quickly lower the PDR (higher noise, Rayleigh fading, extra path loss).
 3. Provide the INI file path to `Simulator(config_file=...)` or use **Positions manuelles** to enter the coordinates manually.
 4. Fill in **Graine** to keep the exact placement across runs.
 5. Or run `python examples/run_flora_example.py` which combines these settings.

--- a/simulateur_lora_sfrd_4.0/examples/run_flora_example.py
+++ b/simulateur_lora_sfrd_4.0/examples/run_flora_example.py
@@ -19,7 +19,7 @@ NODE_POSITIONS = [
 GW_POSITION = (500.0, 500.0)
 
 
-def run_simulation(runs: int, seed: int | None = None, flora_csv: str | None = None):
+def run_simulation(runs: int, seed: int | None = None, flora_csv: str | None = None, degrade: bool = False):
     metrics = []
     for i in range(runs):
         sim = Simulator(
@@ -38,7 +38,7 @@ def run_simulation(runs: int, seed: int | None = None, flora_csv: str | None = N
             seed=(seed + i) if seed is not None else None,
         )
         # apply ADR 1 settings
-        adr1(sim)
+        adr1(sim, degrade_channel=degrade)
         # override positions
         gw = sim.gateways[0]
         gw.x, gw.y = GW_POSITION
@@ -68,8 +68,9 @@ def main():
     parser.add_argument("--runs", type=int, default=5, help="Number of runs")
     parser.add_argument("--seed", type=int, help="Base random seed")
     parser.add_argument("--flora-csv", type=str, help="Path to reference FLoRa CSV")
+    parser.add_argument("--degrade", action="store_true", help="Apply harsh channel settings")
     args = parser.parse_args()
-    run_simulation(args.runs, args.seed, args.flora_csv)
+    run_simulation(args.runs, args.seed, args.flora_csv, args.degrade)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- extend `adr_standard_1.apply` with a `degrade_channel` parameter
- document the new option in VERSION_4/README
- support `--degrade` flag in `run_flora_example.py`
- mention the flag in the main README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b72328bfc8331883013b1a0d39318