### PR TITLE
Fix interference penalty logic

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/advanced_channel.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/advanced_channel.py
@@ -310,5 +310,5 @@ class AdvancedChannel:
             symbol_time = 1.0 / bw
         time_factor = abs(sync_offset_s) / symbol_time
         if freq_factor >= 1.0 and time_factor >= 1.0:
-            return 0.0
+            return float("inf")
         return 10 * math.log10(1.0 + freq_factor ** 2 + time_factor ** 2)


### PR DESCRIPTION
## Summary
- return `float('inf')` when frequency and sync offsets exceed limits

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687b8deb6e848331906fe07458b6c813