### PR TITLE
Fix style issues for ruff

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/lorawan.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/lorawan.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass, field
+from .crypto import aes_encrypt, aes_decrypt, cmac
 
 
 @dataclass
@@ -706,8 +707,6 @@ def next_ping_slot_time(
 # ---------------------------------------------------------------------------
 # LoRaWAN security helpers (AES encryption and MIC)
 # ---------------------------------------------------------------------------
-from .crypto import aes_encrypt, aes_decrypt, cmac
-
 
 def encrypt_payload(
     app_skey: bytes,

--- a/simulateur_lora_sfrd_4.0/tests/test_fast_forward_regression.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_fast_forward_regression.py
@@ -1,3 +1,4 @@
+# ruff: noqa: E402
 import importlib.util
 import pytest
 


### PR DESCRIPTION
## Summary
- move crypto import to top of lorawan module
- silence ruff E402 in regression test

## Testing
- `pytest -q`
- `ruff check VERSION_4/launcher/lorawan.py tests/test_fast_forward_regression.py`


------
https://chatgpt.com/codex/tasks/task_e_687b9758cbb88331bf57e31a867b1e5b