### PR TITLE
Add packet interval jitter for more randomness

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/README.md
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/README.md
@@ -131,6 +131,8 @@ scénarios FLoRa. Voici la liste complète des options :
   passerelles.
 - `transmission_mode` : `Random` (émissions Poisson) ou `Periodic`.
 - `packet_interval` : moyenne ou période fixe entre transmissions (s).
+- `interval_variation` : coefficient de jitter appliqué à l'intervalle
+  exponentiel pour renforcer l'aléa (0 pour désactiver).
 - `packets_to_send` : nombre de paquets émis **par nœud** avant arrêt (0 = infini).
 - `adr_node` / `adr_server` : active l'ADR côté nœud ou serveur.
 - `duty_cycle` : quota d'émission appliqué à chaque nœud (`None` pour désactiver).


### PR DESCRIPTION
## Summary
- introduce `interval_variation` parameter to `Simulator`
- jitter exponential packet interval with `_sample_interval`
- document the new parameter in the simulator README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ba016037483318de23f4d8ccbb179