### PR TITLE
Fix interval variation validation

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/README.md
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/README.md
@@ -132,7 +132,7 @@ scénarios FLoRa. Voici la liste complète des options :
 - `transmission_mode` : `Random` (émissions Poisson) ou `Periodic`.
 - `packet_interval` : moyenne ou période fixe entre transmissions (s).
 - `interval_variation` : coefficient de jitter appliqué à l'intervalle
-  exponentiel pour renforcer l'aléa (0,1 par défaut).
+  exponentiel pour renforcer l'aléa (valeur entre 0 et 1, 0,1 par défaut).
 - `packets_to_send` : nombre de paquets émis **par nœud** avant arrêt (0 = infini).
 - `adr_node` / `adr_server` : active l'ADR côté nœud ou serveur.
 - `duty_cycle` : quota d'émission appliqué à chaque nœud (`None` pour désactiver).

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/simulator.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/simulator.py
@@ -117,6 +117,8 @@ class Simulator:
         self.area_size = area_size
         self.transmission_mode = transmission_mode
         self.packet_interval = packet_interval
+        if interval_variation < 0 or interval_variation > 1:
+            raise ValueError("interval_variation must be between 0 and 1")
         self.interval_variation = interval_variation
         self.packets_to_send = packets_to_send
         self.adr_node = adr_node


### PR DESCRIPTION
## Summary
- validate `interval_variation` parameter in `Simulator`
- document allowed range for jitter in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ba34333948331881b655f358fbec5