### PR TITLE
Tune ADR1 degrade params and make interval jitter impactful

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/README.md
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/README.md
@@ -132,7 +132,7 @@ scénarios FLoRa. Voici la liste complète des options :
 - `transmission_mode` : `Random` (émissions Poisson) ou `Periodic`.
 - `packet_interval` : moyenne ou période fixe entre transmissions (s).
 - `interval_variation` : coefficient de jitter appliqué à l'intervalle
-  exponentiel pour renforcer l'aléa (valeur entre 0 et 1, 0,1 par défaut).
+  exponentiel pour renforcer l'aléa (valeur entre 0 et 1, 1 par défaut).
 - `packets_to_send` : nombre de paquets émis **par nœud** avant arrêt (0 = infini).
 - `adr_node` / `adr_server` : active l'ADR côté nœud ou serveur.
 - `duty_cycle` : quota d'émission appliqué à chaque nœud (`None` pour désactiver).

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/adr_standard_1.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/adr_standard_1.py
@@ -34,15 +34,15 @@ def apply(sim: Simulator, *, degrade_channel: bool = False) -> None:
     if degrade_channel:
         for ch in sim.multichannel.channels:
             base = ch.base if isinstance(ch, AdvancedChannel) else ch
-            # Stronger continuous interference
-            base.interference_dB = max(base.interference_dB, 20.0)
+            # Stronger continuous interference (slightly reduced)
+            base.interference_dB = max(base.interference_dB, 15.0)
             # Wider fast fading margin
-            base.fast_fading_std = max(base.fast_fading_std, 8.0)
+            base.fast_fading_std = max(base.fast_fading_std, 6.0)
             # Higher path loss exponent to increase attenuation
-            base.path_loss_exp = max(base.path_loss_exp, 3.5)
+            base.path_loss_exp = max(base.path_loss_exp, 3.0)
             # More sensitive detection threshold
-            base.detection_threshold_dBm = max(base.detection_threshold_dBm, -90.0)
+            base.detection_threshold_dBm = max(base.detection_threshold_dBm, -88.0)
             if isinstance(ch, AdvancedChannel):
                 ch.fading = "rayleigh"
-                ch.weather_loss_dB_per_km = max(ch.weather_loss_dB_per_km, 1.0)
-        sim.detection_threshold_dBm = -90.0
+                ch.weather_loss_dB_per_km = max(ch.weather_loss_dB_per_km, 0.5)
+        sim.detection_threshold_dBm = -88.0

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/dashboard.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/dashboard.py
@@ -93,7 +93,7 @@ mode_select = pn.widgets.RadioButtonGroup(
     name="Mode d'émission", options=["Aléatoire", "Périodique"], value="Aléatoire"
 )
 interval_input = pn.widgets.FloatInput(name="Intervalle moyen (s)", value=30.0, step=1.0, start=0.1)
-interval_var_input = pn.widgets.FloatInput(name="Variabilité intervalle", value=0.1, step=0.01, start=0.0)
+interval_var_input = pn.widgets.FloatInput(name="Variabilité intervalle", value=1.0, step=0.01, start=0.0)
 interval_var_input.disabled = False
 packets_input = pn.widgets.IntInput(
     name="Nombre de paquets par nœud (0=infin)", value=0, step=1, start=0

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/simulator.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/simulator.py
@@ -49,7 +49,7 @@ class Simulator:
 
     def __init__(self, num_nodes: int = 10, num_gateways: int = 1, area_size: float = 1000.0,
                  transmission_mode: str = 'Random', packet_interval: float = 60.0,
-                 interval_variation: float = 0.1,
+                 interval_variation: float = 1.0,
                  packets_to_send: int = 0, adr_node: bool = False, adr_server: bool = False,
                  duty_cycle: float | None = 0.01, mobility: bool = True,
                  channels=None, channel_distribution: str = "round-robin",
@@ -74,8 +74,8 @@ class Simulator:
         :param transmission_mode: 'Random' pour transmissions aléatoires (Poisson) ou 'Periodic' pour périodiques.
         :param packet_interval: Intervalle moyen entre transmissions (si Random, moyenne en s; si Periodic, période fixe en s).
         :param interval_variation: Jitter relatif appliqué à chaque intervalle
-            exponentiel. Une valeur de ``0.1`` applique un facteur aléatoire
-            compris entre 0.9 et 1.1 pour augmenter la variabilité.
+            exponentiel. Une valeur de ``1`` applique un facteur aléatoire
+            compris entre 0 et 2 pour maximiser la variabilité.
         :param packets_to_send: Nombre de paquets à émettre **par nœud** avant
             d'arrêter la simulation (0 = infini).
         :param adr_node: Activation de l'ADR côté nœud.


### PR DESCRIPTION
## Summary
- soften the degraded channel in ADR1 so nodes still communicate
- make `interval_variation` default to 1.0
- update dashboard default and documentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bbdf373448331a7e71bb555984bf4