### PR TITLE
Improve harsh channel mode

### DIFF
--- a/simulateur_lora_sfrd_4.0/README.md
+++ b/simulateur_lora_sfrd_4.0/README.md
@@ -125,9 +125,10 @@ official detection threshold, interference window and a ``flora`` propagation
   metrics with an official FLoRa export using `compare_with_sim`. FLoRa stores
   its results in `.sca` and `.vec` files. You may convert them to CSV with
   external tools if needed.
-Passing `--degrade` to the script will enable a very harsh channel to quickly
-lower the PDR by raising the noise, applying Rayleigh fading and extra path
-loss.
+Passing `--degrade` to the script enables a harsh propagation profile that
+further decreases the PDR. In this mode additional interference, stronger
+fast fading and a higher path loss exponent are applied.  A slow varying noise
+term is also introduced so repeated runs yield more diverse results.
 
 An example configuration file named `examples/flora_full.ini` reproduces the
 official positions used by FLoRa. Load it with

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/adr_standard_1.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/adr_standard_1.py
@@ -34,15 +34,17 @@ def apply(sim: Simulator, *, degrade_channel: bool = False) -> None:
     if degrade_channel:
         for ch in sim.multichannel.channels:
             base = ch.base if isinstance(ch, AdvancedChannel) else ch
-            # Stronger continuous interference (slightly reduced)
-            base.interference_dB = max(base.interference_dB, 15.0)
+            # Stronger continuous interference
+            base.interference_dB = max(base.interference_dB, 18.0)
             # Wider fast fading margin
-            base.fast_fading_std = max(base.fast_fading_std, 6.0)
+            base.fast_fading_std = max(base.fast_fading_std, 8.0)
             # Higher path loss exponent to increase attenuation
-            base.path_loss_exp = max(base.path_loss_exp, 3.0)
+            base.path_loss_exp = max(base.path_loss_exp, 3.3)
             # More sensitive detection threshold
-            base.detection_threshold_dBm = max(base.detection_threshold_dBm, -88.0)
+            base.detection_threshold_dBm = max(base.detection_threshold_dBm, -86.0)
+            # Add slow varying noise for extra randomness
+            base.noise_floor_std = max(base.noise_floor_std, 2.0)
             if isinstance(ch, AdvancedChannel):
                 ch.fading = "rayleigh"
-                ch.weather_loss_dB_per_km = max(ch.weather_loss_dB_per_km, 0.5)
-        sim.detection_threshold_dBm = -88.0
+                ch.weather_loss_dB_per_km = max(ch.weather_loss_dB_per_km, 1.0)
+        sim.detection_threshold_dBm = -86.0


### PR DESCRIPTION
## Summary
- increase the interference and fading parameters used in harsh mode
- mention extra randomness in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bc029f68883319392968a0d5dd0da