### PR TITLE
Fix Class C scheduling return value

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/downlink_scheduler.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/downlink_scheduler.py
@@ -56,13 +56,14 @@ class DownlinkScheduler:
         return t
 
     def schedule_class_c(self, node, time: float, frame, gateway):
-        """Schedule a frame for a Class C node at ``time``."""
+        """Schedule a frame for a Class C node at ``time`` and return it."""
         duration = node.channel.airtime(node.sf, self._payload_length(frame))
         busy = self._gateway_busy.get(gateway.id, 0.0)
         if time < busy:
             time = busy
         self.schedule(node.id, time, frame, gateway)
         self._gateway_busy[gateway.id] = time + duration
+        return time
 
     def schedule_beacon(self, after_time: float, frame, gateway, beacon_interval: float) -> float:
         """Schedule a beacon frame at the next beacon time after ``after_time``."""

--- a/simulateur_lora_sfrd_4.0/tests/test_scheduler.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_scheduler.py
@@ -73,3 +73,18 @@ def test_scheduler_conflict_resolution():
         2.0,
     )
     assert t2 > t1
+
+
+def test_schedule_class_c_returns_time():
+    node = Node(1, 0.0, 0.0, 7, 14.0, channel=Channel())
+    node.class_type = "C"
+    gw = Gateway(1, 0.0, 0.0)
+    sched = DownlinkScheduler()
+    from VERSION_4.launcher.lorawan import LoRaWANFrame
+
+    frame = LoRaWANFrame(mhdr=0x60, fctrl=0, fcnt=0, payload=b"a")
+    t0 = sched.schedule_class_c(node, 0.0, frame, gw)
+    assert t0 == 0.0
+    # Scheduling another frame before gateway is free should defer it
+    t1 = sched.schedule_class_c(node, 0.0, frame, gw)
+    assert t1 > t0


### PR DESCRIPTION
## Summary
- ensure `schedule_class_c` returns the scheduled time like other helpers
- test the new return behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bc11c05088331abfabcf267e3b5c6