### PR TITLE
Enhance randomness and degrade channel

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/README.md
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/README.md
@@ -132,7 +132,8 @@ scénarios FLoRa. Voici la liste complète des options :
 - `transmission_mode` : `Random` (émissions Poisson) ou `Periodic`.
 - `packet_interval` : moyenne ou période fixe entre transmissions (s).
 - `interval_variation` : coefficient de jitter appliqué à l'intervalle
-  exponentiel pour renforcer l'aléa (valeur entre 0 et 1, 1 par défaut).
+  exponentiel pour renforcer l'aléa (valeur positive, 1 par défaut ; une
+  valeur supérieure augmente la dispersion).
 - `packets_to_send` : nombre de paquets émis **par nœud** avant arrêt (0 = infini).
 - `adr_node` / `adr_server` : active l'ADR côté nœud ou serveur.
 - `duty_cycle` : quota d'émission appliqué à chaque nœud (`None` pour désactiver).
@@ -295,7 +296,7 @@ paramètre `fast_fading_std` afin de simuler un canal multipath et utiliser
 
 To reproduce FLoRa INI scenarios:
 1. Pass `flora_mode=True` when creating the `Simulator` (or enable **Mode FLoRa complet**). This applies the official `-110 dBm` detection threshold and a `5 s` interference window.
-2. Apply the ADR1 algorithm with `from VERSION_4.launcher.adr_standard_1 import apply as adr1` then `adr1(sim)`. This preset now mirrors the ADR logic of the original FLoRa server (SNR history, margin and multi‑step adjustments). Passing `degrade_channel=True` enables a harsh propagation profile to quickly lower the PDR (higher noise, Rayleigh fading, extra path loss).
+2. Apply the ADR1 algorithm with `from VERSION_4.launcher.adr_standard_1 import apply as adr1` then `adr1(sim)`. This preset mirrors the ADR logic of the original FLoRa server (SNR history, margin and multi‑step adjustments). Using `degrade_channel=True` now applies even stronger propagation impairments to rapidly lower the PDR.
 3. Provide the INI file path to `Simulator(config_file=...)` or use **Positions manuelles** to enter the coordinates manually.
 4. Fill in **Graine** to keep the exact placement across runs.
 5. Or run `python examples/run_flora_example.py` which combines these settings.

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/adr_standard_1.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/adr_standard_1.py
@@ -35,16 +35,16 @@ def apply(sim: Simulator, *, degrade_channel: bool = False) -> None:
         for ch in sim.multichannel.channels:
             base = ch.base if isinstance(ch, AdvancedChannel) else ch
             # Stronger continuous interference
-            base.interference_dB = max(base.interference_dB, 18.0)
+            base.interference_dB = max(base.interference_dB, 25.0)
             # Wider fast fading margin
-            base.fast_fading_std = max(base.fast_fading_std, 8.0)
+            base.fast_fading_std = max(base.fast_fading_std, 12.0)
             # Higher path loss exponent to increase attenuation
-            base.path_loss_exp = max(base.path_loss_exp, 3.3)
+            base.path_loss_exp = max(base.path_loss_exp, 3.8)
             # More sensitive detection threshold
-            base.detection_threshold_dBm = max(base.detection_threshold_dBm, -86.0)
+            base.detection_threshold_dBm = max(base.detection_threshold_dBm, -80.0)
             # Add slow varying noise for extra randomness
-            base.noise_floor_std = max(base.noise_floor_std, 2.0)
+            base.noise_floor_std = max(base.noise_floor_std, 4.0)
             if isinstance(ch, AdvancedChannel):
                 ch.fading = "rayleigh"
-                ch.weather_loss_dB_per_km = max(ch.weather_loss_dB_per_km, 1.0)
-        sim.detection_threshold_dBm = -86.0
+                ch.weather_loss_dB_per_km = max(ch.weather_loss_dB_per_km, 2.0)
+        sim.detection_threshold_dBm = -80.0

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/simulator.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/simulator.py
@@ -75,7 +75,8 @@ class Simulator:
         :param packet_interval: Intervalle moyen entre transmissions (si Random, moyenne en s; si Periodic, période fixe en s).
         :param interval_variation: Jitter relatif appliqué à chaque intervalle
             exponentiel. Une valeur de ``1`` applique un facteur aléatoire
-            compris entre 0 et 2 pour maximiser la variabilité.
+            compris entre 0 et 2 pour maximiser la variabilité. Des valeurs
+            supérieures accentuent encore la dispersion.
         :param packets_to_send: Nombre de paquets à émettre **par nœud** avant
             d'arrêter la simulation (0 = infini).
         :param adr_node: Activation de l'ADR côté nœud.
@@ -117,8 +118,8 @@ class Simulator:
         self.area_size = area_size
         self.transmission_mode = transmission_mode
         self.packet_interval = packet_interval
-        if interval_variation < 0 or interval_variation > 1:
-            raise ValueError("interval_variation must be between 0 and 1")
+        if interval_variation < 0 or interval_variation > 3:
+            raise ValueError("interval_variation must be between 0 and 3")
         self.interval_variation = interval_variation
         self.packets_to_send = packets_to_send
         self.adr_node = adr_node
@@ -316,9 +317,9 @@ class Simulator:
         """Retourne un délai tiré de la loi exponentielle avec jitter."""
         interval = random.expovariate(1.0 / self.packet_interval)
         if self.interval_variation > 0.0:
-            factor = random.uniform(
-                1.0 - self.interval_variation, 1.0 + self.interval_variation
-            )
+            low = max(0.0, 1.0 - self.interval_variation)
+            high = 1.0 + self.interval_variation
+            factor = random.uniform(low, high)
             interval *= factor
         return interval
 


### PR DESCRIPTION
## Summary
- allow larger jitter range for exponential intervals
- document interval variation range in README
- apply stronger channel degradation in ADR preset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bc4222cd483318153e339f3f2d222