### PR TITLE
Fix PER threshold

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/simulator.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/simulator.py
@@ -48,7 +48,7 @@ class Simulator:
     # Ajustement pour réagir plus vite aux liaisons dégradées
     # Une valeur plus basse améliore en général le PDR au prix de plus
     # de transmissions et de réglages ADR plus fréquents
-    PER_THRESHOLD = 0.05        # Seuil de Packet Error Rate pour déclencher ADR
+    PER_THRESHOLD = 0.1         # Seuil de Packet Error Rate pour déclencher ADR
 
     def __init__(self, num_nodes: int = 10, num_gateways: int = 1, area_size: float = 1000.0,
                  transmission_mode: str = 'Random', packet_interval: float = 60.0,


### PR DESCRIPTION
## Summary
- set `PER_THRESHOLD` back to 0.1 in the simulator

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687bcc85e84883319f4fb05401aaacaf