### PR TITLE
Fix ping slot scheduling when beacon lost

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/node.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/node.py
@@ -671,10 +671,15 @@ class Node:
         ping_slot_offset: float,
     ) -> float:
         """Return the next ping slot time after ``current_time``."""
-        from .lorawan import next_ping_slot_time
+        from .lorawan import next_ping_slot_time, next_beacon_time
+
+        last_beacon = self.last_beacon_time
+        # If the last beacon is too old, resynchronise to the nominal schedule
+        if current_time - last_beacon > beacon_interval * 2:
+            last_beacon = next_beacon_time(current_time, beacon_interval)
 
         return next_ping_slot_time(
-            self.last_beacon_time,
+            last_beacon,
             current_time,
             self.ping_slot_periodicity or 0,
             ping_slot_interval,


### PR DESCRIPTION
## Summary
- use beacon interval to recover lost Class B beacons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cc47a4d108331a56582c04c64fdf9