### PR TITLE
Improve PHY realism and attenuation models

### DIFF
--- a/simulateur_lora_sfrd_4.0/README.md
+++ b/simulateur_lora_sfrd_4.0/README.md
@@ -1,6 +1,6 @@
 # LoRa Network Simulator 4.0
 
-This repository contains a lightweight LoRa network simulator implemented in Python. The latest code resides in the `VERSION_4` directory and is based on a simplified version of the FLoRa model so it can run without OMNeT++. This approach omits the detailed OMNeT++ physical layer, which may reduce accuracy compared to full-stack simulators.
+This repository contains a lightweight LoRa network simulator implemented in Python. The latest code resides in the `VERSION_4` directory and now integrates a simplified OMNeT++ physical layer for frequency and clock drifts as well as thermal noise. It remains independent from the full simulator stack.
 
 ## Features
 - Duty cycle enforcement to mimic real LoRa constraints
@@ -8,6 +8,7 @@ This repository contains a lightweight LoRa network simulator implemented in Pyt
 - Multi-channel radio support
 - Advanced channel model with loss and noise parameters
 - Optional multipath fading with synchronised paths and external interference modeling
+- Correlated fading and 3D obstacle maps with automatic calibration
 - Antenna gains and cable losses for accurate link budgets
 - Optional LoRa spreading gain applied to SNR
 - Additional COST231 path loss, Okumura‑Hata model and 3D propagation via
@@ -267,6 +268,9 @@ the current directory.
 The resulting parameters typically give a correspondence above **99 %** with
 FLoRa on the provided dataset. The calibration is also executed during the
 test suite to ensure the simulator stays in sync with the reference model.
+
+Pass ``--advanced`` to also optimise the correlated fading coefficient and
+the obstacle attenuation when using ``AdvancedChannel``.
 
 To check several FLoRa exports at once and average the error over all of them
 use:

--- a/simulateur_lora_sfrd_4.0/VERSION_4/README.md
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/README.md
@@ -226,6 +226,8 @@ constructeur de `Channel` classique et restent compatibles avec le
 tableau de bord. Les modèles ``rayleigh`` et ``rician`` utilisent
 désormais une corrélation temporelle pour reproduire le comportement de
 FLoRa et un bruit variable peut être ajouté via ``variable_noise_std``.
+Une carte ``obstacle_height_map`` peut bloquer complètement un lien en
+fonction de l'altitude parcourue.
 
 Le tableau de bord propose désormais un bouton **Mode FLoRa complet**. Quand il
 est activé, `detection_threshold_dBm` est automatiquement fixé à `-110` dBm et

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/channel.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/channel.py
@@ -42,7 +42,7 @@ class Channel:
         fading_correlation: float = 0.9,
         variable_noise_std: float = 0.0,
         advanced_capture: bool = False,
-        phy_model: str = "",
+        phy_model: str = "omnet",
         system_loss_dB: float = 0.0,
         rssi_offset_dB: float = 0.0,
         snr_offset_dB: float = 0.0,
@@ -91,7 +91,7 @@ class Channel:
             fading et le bruit variable.
         :param variable_noise_std: Variation lente du bruit thermique en dB.
         :param advanced_capture: Active un mode de capture inspiré de FLoRa.
-        :param phy_model: "omnet" pour utiliser le module OMNeT++.
+        :param phy_model: "omnet" (par défaut) pour utiliser le module OMNeT++.
         :param system_loss_dB: Pertes fixes supplémentaires (par ex. pertes
             système) appliquées à la perte de parcours.
         :param rssi_offset_dB: Décalage appliqué au RSSI calculé (dB).
@@ -163,6 +163,9 @@ class Channel:
             clock_drift_std=clock_drift_std_s,
             temperature_K=temperature_K,
         )
+        self.fine_fading_std = fine_fading_std
+        self.fading_correlation = fading_correlation
+        self.variable_noise_std = variable_noise_std
         self.advanced_capture = advanced_capture
         self.phy_model = phy_model
         self.system_loss_dB = system_loss_dB

--- a/simulateur_lora_sfrd_4.0/tests/test_advanced_channel.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_advanced_channel.py
@@ -85,3 +85,27 @@ def test_obstacle_map_extra_loss():
         rx_pos=(90.0, 90.0),
     )
     assert r_obst < r_clear
+
+
+def test_obstacle_height_blocks_link():
+    obstacle_h = [
+        [0.0, 0.0],
+        [5.0, 0.0],
+    ]
+    obstacle = [
+        [0.0, 0.0],
+        [-1.0, 0.0],
+    ]
+    adv = AdvancedChannel(
+        obstacle_height_map=obstacle_h,
+        obstacle_map=obstacle,
+        map_area_size=100.0,
+        fading="",
+    )
+    r, s = adv.compute_rssi(
+        14.0,
+        80.0,
+        tx_pos=(10.0, 90.0, 0.0),
+        rx_pos=(90.0, 90.0, 0.0),
+    )
+    assert r == -float("inf")

--- a/simulateur_lora_sfrd_4.0/tests/test_calibrate_flora.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_calibrate_flora.py
@@ -12,6 +12,13 @@ from tools.calibrate_flora import calibrate  # noqa: E402
 
 def test_calibrate_flora_quick():
     ref = Path(__file__).parent / "data" / "flora_full.csv"
-    params, err = calibrate(ref, runs=1, path_loss_values=(2.7,), shadowing_values=(6.0,), seed=0)
+    params, err = calibrate(
+        ref,
+        runs=1,
+        path_loss_values=(2.7,),
+        shadowing_values=(6.0,),
+        seed=0,
+        advanced=True,
+    )
     assert params is not None
     assert err >= 0.0

--- a/simulateur_lora_sfrd_4.0/tools/calibrate_flora.py
+++ b/simulateur_lora_sfrd_4.0/tools/calibrate_flora.py
@@ -13,6 +13,7 @@ sys.path.insert(0, str(ROOT))
 
 from VERSION_4.launcher.simulator import Simulator  # noqa: E402
 from VERSION_4.launcher.channel import Channel  # noqa: E402
+from VERSION_4.launcher.advanced_channel import AdvancedChannel  # noqa: E402
 from VERSION_4.launcher.adr_standard_1 import apply as adr1  # noqa: E402
 from VERSION_4.launcher.compare_flora import load_flora_metrics  # noqa: E402
 
@@ -67,12 +68,66 @@ def _run_sim(path_loss_exp: float, shadowing_std: float, runs: int, seed: int | 
     return avg
 
 
+def _run_sim_advanced(
+    path_loss_exp: float,
+    shadowing_std: float,
+    fading_corr: float,
+    obstacle_dB: float,
+    runs: int,
+    seed: int | None,
+) -> dict[str, float]:
+    metrics = []
+    for i in range(runs):
+        ch = AdvancedChannel(
+            propagation_model="3d",
+            fading="rayleigh",
+            fading_correlation=fading_corr,
+            default_obstacle_dB=obstacle_dB,
+            path_loss_exp=path_loss_exp,
+            shadowing_std=shadowing_std,
+            detection_threshold_dBm=-110.0,
+        )
+        sim = Simulator(
+            num_nodes=5,
+            num_gateways=1,
+            area_size=1000.0,
+            transmission_mode="Random",
+            packet_interval=100.0,
+            packets_to_send=80,
+            adr_node=True,
+            adr_server=True,
+            mobility=False,
+            fixed_sf=12,
+            fixed_tx_power=14.0,
+            channels=[ch],
+            detection_threshold_dBm=-110.0,
+            min_interference_time=5.0,
+            seed=(seed + i) if seed is not None else None,
+        )
+        adr1(sim)
+        gw = sim.gateways[0]
+        gw.x, gw.y = GW_POSITION
+        for node, pos in zip(sim.nodes, NODE_POSITIONS):
+            node.x, node.y = pos
+            node.initial_x, node.initial_y = pos
+        sim.run()
+        metrics.append(sim.get_metrics())
+    avg: dict[str, float] = {}
+    for k in metrics[0]:
+        if isinstance(metrics[0][k], (int, float)):
+            avg[k] = sum(m[k] for m in metrics) / len(metrics)
+    return avg
+
+
 def calibrate(
     flora_csv: str | Path,
     runs: int = 3,
     path_loss_values: tuple[float, ...] = (2.5, 2.7, 2.9),
     shadowing_values: tuple[float, ...] = (2.0, 4.0, 6.0),
+    fading_corr_values: tuple[float, ...] = (0.9,),
+    obstacle_values: tuple[float, ...] = (0.0,),
     *,
+    advanced: bool = False,
     seed: int | None = None,
 ) -> tuple[dict[str, float] | None, float]:
     """Return best parameters minimizing the PDR difference."""
@@ -81,11 +136,30 @@ def calibrate(
     best_params: dict[str, float] | None = None
     for pl in path_loss_values:
         for sh in shadowing_values:
-            m = _run_sim(pl, sh, runs, seed)
-            err = abs(m.get("PDR", 0.0) - flora.get("PDR", 0.0))
-            if err < best_err:
-                best_err = err
-                best_params = {"path_loss_exp": pl, "shadowing_std": sh, "PDR": m.get("PDR", 0.0)}
+            if advanced:
+                for fc in fading_corr_values:
+                    for ob in obstacle_values:
+                        m = _run_sim_advanced(pl, sh, fc, ob, runs, seed)
+                        err = abs(m.get("PDR", 0.0) - flora.get("PDR", 0.0))
+                        if err < best_err:
+                            best_err = err
+                            best_params = {
+                                "path_loss_exp": pl,
+                                "shadowing_std": sh,
+                                "fading_correlation": fc,
+                                "obstacle_dB": ob,
+                                "PDR": m.get("PDR", 0.0),
+                            }
+            else:
+                m = _run_sim(pl, sh, runs, seed)
+                err = abs(m.get("PDR", 0.0) - flora.get("PDR", 0.0))
+                if err < best_err:
+                    best_err = err
+                    best_params = {
+                        "path_loss_exp": pl,
+                        "shadowing_std": sh,
+                        "PDR": m.get("PDR", 0.0),
+                    }
     if best_params:
         print(f"Best parameters: {best_params} (PDR diff {best_err:.4f})")
     return best_params, best_err
@@ -96,7 +170,10 @@ def cross_validate(
     runs: int = 3,
     path_loss_values: tuple[float, ...] = (2.5, 2.7, 2.9),
     shadowing_values: tuple[float, ...] = (2.0, 4.0, 6.0),
+    fading_corr_values: tuple[float, ...] = (0.9,),
+    obstacle_values: tuple[float, ...] = (0.0,),
     *,
+    advanced: bool = False,
     seed: int | None = None,
 ) -> tuple[dict[str, float] | None, float]:
     """Return best parameters averaged over multiple datasets."""
@@ -105,20 +182,52 @@ def cross_validate(
     best_params: dict[str, float] | None = None
     for pl in path_loss_values:
         for sh in shadowing_values:
-            err = 0.0
-            for idx, flora in enumerate(refs):
-                m = _run_sim(pl, sh, runs, (seed + idx) if seed is not None else None)
-                pdr_diff = abs(m.get("PDR", 0.0) - flora.get("PDR", 0.0))
-                sim_sf = m.get("sf_distribution", {})
-                flora_sf = flora.get("sf_distribution", {})
-                all_sf = set(sim_sf) | set(flora_sf)
-                sf_diff = sum(abs(sim_sf.get(sf, 0) - flora_sf.get(sf, 0)) for sf in all_sf)
-                norm = max(sum(flora_sf.values()), 1)
-                err += pdr_diff + sf_diff / norm
-            err /= len(refs)
-            if err < best_err:
-                best_err = err
-                best_params = {"path_loss_exp": pl, "shadowing_std": sh}
+            if advanced:
+                for fc in fading_corr_values:
+                    for ob in obstacle_values:
+                        err = 0.0
+                        for idx, flora in enumerate(refs):
+                            m = _run_sim_advanced(
+                                pl,
+                                sh,
+                                fc,
+                                ob,
+                                runs,
+                                (seed + idx) if seed is not None else None,
+                            )
+                            pdr_diff = abs(m.get("PDR", 0.0) - flora.get("PDR", 0.0))
+                            sim_sf = m.get("sf_distribution", {})
+                            flora_sf = flora.get("sf_distribution", {})
+                            all_sf = set(sim_sf) | set(flora_sf)
+                            sf_diff = sum(
+                                abs(sim_sf.get(sf, 0) - flora_sf.get(sf, 0)) for sf in all_sf
+                            )
+                            norm = max(sum(flora_sf.values()), 1)
+                            err += pdr_diff + sf_diff / norm
+                        err /= len(refs)
+                        if err < best_err:
+                            best_err = err
+                            best_params = {
+                                "path_loss_exp": pl,
+                                "shadowing_std": sh,
+                                "fading_correlation": fc,
+                                "obstacle_dB": ob,
+                            }
+            else:
+                err = 0.0
+                for idx, flora in enumerate(refs):
+                    m = _run_sim(pl, sh, runs, (seed + idx) if seed is not None else None)
+                    pdr_diff = abs(m.get("PDR", 0.0) - flora.get("PDR", 0.0))
+                    sim_sf = m.get("sf_distribution", {})
+                    flora_sf = flora.get("sf_distribution", {})
+                    all_sf = set(sim_sf) | set(flora_sf)
+                    sf_diff = sum(abs(sim_sf.get(sf, 0) - flora_sf.get(sf, 0)) for sf in all_sf)
+                    norm = max(sum(flora_sf.values()), 1)
+                    err += pdr_diff + sf_diff / norm
+                err /= len(refs)
+                if err < best_err:
+                    best_err = err
+                    best_params = {"path_loss_exp": pl, "shadowing_std": sh}
     if best_params:
         print(f"Best parameters: {best_params} (avg error {best_err:.4f})")
     return best_params, best_err
@@ -135,11 +244,17 @@ def main() -> None:
     )
     parser.add_argument("--runs", type=int, default=3, help="Runs per parameter set")
     parser.add_argument("--seed", type=int, help="Base random seed")
+    parser.add_argument("--advanced", action="store_true", help="Use advanced channel")
     args = parser.parse_args()
     if len(args.flora_csv) == 1:
-        calibrate(Path(args.flora_csv[0]), runs=args.runs, seed=args.seed)
+        calibrate(Path(args.flora_csv[0]), runs=args.runs, seed=args.seed, advanced=args.advanced)
     else:
-        cross_validate([Path(p) for p in args.flora_csv], runs=args.runs, seed=args.seed)
+        cross_validate(
+            [Path(p) for p in args.flora_csv],
+            runs=args.runs,
+            seed=args.seed,
+            advanced=args.advanced,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- default to using the `OmnetPHY` model for all channels
- expose fading parameters in `Channel`
- extend `AdvancedChannel` with obstacle height maps and default loss
- add automatic calibration of correlated fading and obstacle loss
- document advanced calibration and new features
- test 3D obstacle blocking and advanced calibration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ce0e384148331bf12be65d2c74825