### PR TITLE
Add terrain-aware mobility and map loader

### DIFF
--- a/simulateur_lora_sfrd_4.0/README.md
+++ b/simulateur_lora_sfrd_4.0/README.md
@@ -4,11 +4,13 @@ This repository contains a lightweight LoRa network simulator implemented in Pyt
 
 ## Features
 - Duty cycle enforcement to mimic real LoRa constraints
-- Optional node mobility with Bezier interpolation
+- Optional node mobility with Bezier interpolation or terrain-aware random
+  waypoint movement
 - Multi-channel radio support
 - Advanced channel model with loss and noise parameters
 - Optional multipath fading with synchronised paths and external interference modeling
-- Correlated fading and 3D obstacle maps with automatic calibration
+- Correlated fading and 3D obstacle maps with automatic calibration. Obstacle
+  or height maps can be loaded from JSON or plain text matrices
 - Antenna gains and cable losses for accurate link budgets
 - Optional LoRa spreading gain applied to SNR
 - Additional COST231 path loss, Okumura‑Hata model and 3D propagation via
@@ -310,8 +312,8 @@ concepts:
 
 - The physical layer is greatly simplified and does not reproduce hardware
   imperfections found in real devices.
-- Mobility relies on random Bezier paths without obstacles or terrain
-  constraints.
+- By default mobility relies on Bezier paths; an optional RandomWaypoint model
+  can use terrain maps to handle obstacles.
 - Basic LoRaWAN security (AES encryption and MIC) is enabled by default but join
   server handling and encryption validation are kept minimal.
 

--- a/simulateur_lora_sfrd_4.0/VERSION_4/README.md
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/README.md
@@ -385,8 +385,7 @@ encore de maturité :
   réels des modems LoRa.
 - Les classes B et C sont gérées de manière basique : les pertes de beacon ou
   la dérive temporelle ne sont pas simulées.
-- La mobilité s'appuie sur des trajets aléatoires sans prise en compte
-  d'obstacles ou de cartes géographiques.
+- La mobilité par défaut s'appuie sur des trajets de Bézier. Un modèle RandomWaypoint peut exploiter une carte de terrain pour éviter les obstacles.
 - La sécurité LoRaWAN (chiffrement AES/MIC) est activée par défaut mais les
   serveurs de jointure et la validation du chiffrement restent simplifiés.
 

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/__init__.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/__init__.py
@@ -8,6 +8,8 @@ from .server import NetworkServer
 from .simulator import Simulator
 from .duty_cycle import DutyCycleManager
 from .smooth_mobility import SmoothMobility
+from .mobility import RandomWaypoint
+from .map_loader import load_map
 from .lorawan import LoRaWANFrame, compute_rx1, compute_rx2
 from .downlink_scheduler import DownlinkScheduler
 from .omnet_model import OmnetModel
@@ -24,6 +26,8 @@ __all__ = [
     "Simulator",
     "DutyCycleManager",
     "SmoothMobility",
+    "RandomWaypoint",
+    "load_map",
     "LoRaWANFrame",
     "compute_rx1",
     "compute_rx2",

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/advanced_channel.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/advanced_channel.py
@@ -78,6 +78,8 @@ class AdvancedChannel:
         obstacle_map: list[list[float]] | None = None,
         map_area_size: float | None = None,
         obstacle_height_map: list[list[float]] | None = None,
+        obstacle_map_file: str | None = None,
+        obstacle_height_map_file: str | None = None,
         default_obstacle_dB: float = 0.0,
         multipath_paths: int = 1,
         **kwargs,
@@ -114,6 +116,9 @@ class AdvancedChannel:
             de visée. Si la trajectoire passe sous une hauteur positive, la
             pénalité ``default_obstacle_dB`` ou la valeur de ``obstacle_map`` est
             appliquée.
+        :param obstacle_map_file: Fichier JSON ou texte décrivant ``obstacle_map``.
+        :param obstacle_height_map_file: Fichier JSON ou texte décrivant
+            ``obstacle_height_map``.
         :param default_obstacle_dB: Pénalité par défaut en dB lorsqu'un obstacle
             est rencontré sans valeur explicite dans ``obstacle_map``.
         """
@@ -147,6 +152,13 @@ class AdvancedChannel:
         self._sync_offset = _CorrelatedValue(
             sync_offset_s, sync_offset_std_s, fading_correlation
         )
+        if obstacle_map is None and obstacle_map_file:
+            from .map_loader import load_map
+            obstacle_map = load_map(obstacle_map_file)
+        if obstacle_height_map is None and obstacle_height_map_file:
+            from .map_loader import load_map
+            obstacle_height_map = load_map(obstacle_height_map_file)
+
         self.obstacle_map = obstacle_map
         self.obstacle_height_map = obstacle_height_map
         self.default_obstacle_dB = float(default_obstacle_dB)

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/map_loader.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/map_loader.py
@@ -1,0 +1,26 @@
+import json
+from pathlib import Path
+from typing import Iterable, Union, List
+
+
+def load_map(source: Union[str, Path, Iterable[Iterable[float]]]) -> List[List[float]]:
+    """Load a 2D float matrix from a JSON file, plain text matrix or iterable.
+
+    ``source`` can be a path to a JSON file or a simple whitespace separated
+    text file. It can also directly be an iterable of iterables of numbers.
+    Returns a list of list of floats.
+    """
+    if isinstance(source, (str, Path)):
+        path = Path(source)
+        text = path.read_text()
+        if path.suffix.lower() == ".json":
+            data = json.loads(text)
+        else:
+            lines = [line.strip() for line in text.splitlines() if line.strip()]
+            data = [
+                [float(v) for v in line.replace(",", " ").split()]
+                for line in lines
+            ]
+    else:
+        data = [list(row) for row in source]
+    return [[float(v) for v in row] for row in data]

--- a/simulateur_lora_sfrd_4.0/tests/test_map_loader.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_map_loader.py
@@ -1,0 +1,19 @@
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from VERSION_4.launcher.map_loader import load_map  # noqa: E402
+
+
+def test_load_map_json_and_text(tmp_path):
+    data = [[0, 1], [2, 3]]
+    json_file = tmp_path / "map.json"
+    json_file.write_text(json.dumps(data))
+    assert load_map(json_file) == [[0.0, 1.0], [2.0, 3.0]]
+
+    txt_file = tmp_path / "map.txt"
+    txt_file.write_text("0 1\n2 3\n")
+    assert load_map(txt_file) == [[0.0, 1.0], [2.0, 3.0]]

--- a/simulateur_lora_sfrd_4.0/tests/test_random_waypoint.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_random_waypoint.py
@@ -1,0 +1,22 @@
+import sys
+from pathlib import Path
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from VERSION_4.launcher.node import Node  # noqa: E402
+from VERSION_4.launcher.channel import Channel  # noqa: E402
+from VERSION_4.launcher.mobility import RandomWaypoint  # noqa: E402
+
+
+def test_random_waypoint_blocked_cell():
+    terrain = [[1.0, -1.0], [1.0, 1.0]]
+    mob = RandomWaypoint(area_size=100.0, min_speed=10.0, max_speed=10.0, terrain=terrain)
+    node = Node(1, 40.0, 10.0, 7, 14.0, channel=Channel())
+    node.vx = 10.0
+    node.vy = 0.0
+    node.last_move_time = 0.0
+    mob.move(node, 1.0)
+    assert node.x == pytest.approx(40.0)
+    assert node.vx == pytest.approx(-10.0)


### PR DESCRIPTION
## Summary
- allow loading obstacle and height maps via new `load_map` helper
- support map file parameters in `AdvancedChannel`
- add terrain-aware `RandomWaypoint` mobility option
- document mobility improvements and map loading
- test new map loader and RandomWaypoint obstacle handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ce70cca488331a69048a53e58f191