### PR TITLE
Support beacon loss & drift

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/server.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/server.py
@@ -33,6 +33,24 @@ class NetworkServer:
         self.next_devaddr = 1
         self.scheduler = DownlinkScheduler()
         self.join_server = join_server
+        self.beacon_interval = 128.0
+        self.beacon_drift = 0.0
+        self.last_beacon_time: float | None = None
+
+    def next_beacon_time(self, after_time: float) -> float:
+        """Return the next beacon time after ``after_time``."""
+        from .lorawan import next_beacon_time
+
+        return next_beacon_time(
+            after_time,
+            self.beacon_interval,
+            last_beacon=self.last_beacon_time,
+            drift=self.beacon_drift,
+        )
+
+    def notify_beacon(self, time: float) -> None:
+        """Record that a beacon was emitted at ``time``."""
+        self.last_beacon_time = time
 
     # ------------------------------------------------------------------
     # Downlink management


### PR DESCRIPTION
## Summary
- allow configuring beacon drift in simulator and server
- keep scheduling ping slots after a missed beacon
- add methods in `NetworkServer` to compute next beacon time
- test ping slots when beacons are lost
- test quasi continuous ping-slot listening

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ceb370d34833184e66cee7b76608e