### PR TITLE
Add join server class and payload validation

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/server.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/server.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 from .downlink_scheduler import DownlinkScheduler
 
@@ -12,6 +13,57 @@ logger = logging.getLogger(__name__)
 # Paramètres ADR (valeurs issues de la spécification LoRaWAN)
 REQUIRED_SNR = {7: -7.5, 8: -10.0, 9: -12.5, 10: -15.0, 11: -17.5, 12: -20.0}
 MARGIN_DB = 15.0
+
+
+@dataclass
+class JoinServer:
+    """Simple join server verifying AppKey and DevNonce."""
+
+    net_id: int = 0
+    devices: dict[tuple[int, int], bytes] = field(default_factory=dict)
+    last_devnonce: dict[tuple[int, int], int] = field(default_factory=dict)
+    next_devaddr: int = 1
+    app_nonce: int = 1
+
+    def register(self, join_eui: int, dev_eui: int, app_key: bytes) -> None:
+        """Register a device and its associated key."""
+        if len(app_key) != 16:
+            raise ValueError("Invalid AppKey")
+        self.devices[(join_eui, dev_eui)] = app_key
+
+    def handle_join(self, req: "JoinRequest") -> tuple["JoinAccept", bytes, bytes]:
+        """Validate ``req`` and return a join-accept with derived keys."""
+        from .lorawan import (
+            compute_join_mic,
+            derive_session_keys,
+            aes_decrypt,
+            JoinAccept,
+        )
+
+        key = (req.join_eui, req.dev_eui)
+        app_key = self.devices.get(key)
+        if app_key is None:
+            raise KeyError("Unknown device")
+        if compute_join_mic(app_key, req.to_bytes()) != req.mic:
+            raise ValueError("Invalid MIC")
+        last = self.last_devnonce.get(key)
+        if last is not None and req.dev_nonce <= last:
+            raise ValueError("DevNonce reused")
+        self.last_devnonce[key] = req.dev_nonce
+
+        app_nonce = self.app_nonce & 0xFFFFFF
+        self.app_nonce += 1
+        dev_addr = self.next_devaddr
+        self.next_devaddr += 1
+        nwk_skey, app_skey = derive_session_keys(
+            app_key, req.dev_nonce, app_nonce, self.net_id
+        )
+        accept = JoinAccept(app_nonce, self.net_id, dev_addr)
+        msg = accept.to_bytes()
+        pad = (16 - len(msg) % 16) % 16
+        accept.encrypted = aes_decrypt(app_key, msg + bytes(pad))
+        accept.mic = compute_join_mic(app_key, msg)
+        return accept, nwk_skey, app_skey
 
 class NetworkServer:
     """Représente le serveur de réseau LoRa (collecte des paquets reçus)."""

--- a/simulateur_lora_sfrd_4.0/tests/test_lorawan.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_lorawan.py
@@ -162,12 +162,12 @@ def test_next_beacon_time_recover():
 
 def test_join_server_invalid_key_and_rejoin():
     from VERSION_4.launcher.lorawan import (
-        JoinServer,
         JoinRequest,
         JoinAccept,
         compute_join_mic,
         aes_encrypt,
     )
+    from VERSION_4.launcher.server import JoinServer
 
     js = JoinServer(net_id=1)
     app_key = bytes(range(16))

--- a/simulateur_lora_sfrd_4.0/tests/test_otaa.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_otaa.py
@@ -7,8 +7,8 @@ sys.path.insert(0, str(ROOT))
 from VERSION_4.launcher.node import Node  # noqa: E402
 from VERSION_4.launcher.gateway import Gateway  # noqa: E402
 from VERSION_4.launcher.channel import Channel  # noqa: E402
-from VERSION_4.launcher.server import NetworkServer  # noqa: E402
-from VERSION_4.launcher.lorawan import JoinRequest, JoinAccept, JoinServer  # noqa: E402
+from VERSION_4.launcher.server import NetworkServer, JoinServer  # noqa: E402
+from VERSION_4.launcher.lorawan import JoinRequest, JoinAccept  # noqa: E402
 
 
 def test_otaa_join_procedure():

--- a/simulateur_lora_sfrd_4.0/tests/test_security_validation.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_security_validation.py
@@ -1,0 +1,55 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from VERSION_4.launcher.lorawan import (  # noqa: E402
+    LoRaWANFrame,
+    encrypt_payload,
+    compute_mic,
+    validate_frame,
+    validate_join_request,
+    compute_join_mic,
+    JoinRequest,
+)
+
+
+def test_validate_frame_and_join_request():
+    nwk = bytes(range(16))
+    app = bytes(range(16, 32))
+    devaddr = 0x01020304
+    payload = b"hello"
+
+    enc = encrypt_payload(app, devaddr, 1, 0, payload)
+    mic = compute_mic(nwk, devaddr, 1, 0, enc)
+    frame = LoRaWANFrame(
+        mhdr=0x40,
+        fctrl=0,
+        fcnt=1,
+        payload=b"",
+        confirmed=False,
+        mic=mic,
+        encrypted_payload=enc,
+    )
+    assert validate_frame(frame, nwk, app, devaddr, 0)
+    assert frame.payload == payload
+
+    bad = LoRaWANFrame(
+        mhdr=0x40,
+        fctrl=0,
+        fcnt=1,
+        payload=b"",
+        confirmed=False,
+        mic=b"\x00\x00\x00\x00",
+        encrypted_payload=enc,
+    )
+    assert not validate_frame(bad, nwk, app, devaddr, 0)
+
+    key = bytes(range(16))
+    req = JoinRequest(1, 2, 1)
+    req.mic = compute_join_mic(key, req.to_bytes())
+    assert validate_join_request(req, key)
+
+    req.mic = b"\x00\x00\x00\x00"
+    assert not validate_join_request(req, key)


### PR DESCRIPTION
## Summary
- add dedicated JoinServer to server module
- validate LoRaWAN encryption and MIC
- update OTAA test imports to use new JoinServer
- keep backwards compatibility with lorawan.JoinServer
- test validation helpers

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ceb3d21a483318c87e6c863287314