### PR TITLE
Add FLoRa results converter and update comparison utils

### DIFF
--- a/simulateur_lora_sfrd_4.0/README.md
+++ b/simulateur_lora_sfrd_4.0/README.md
@@ -128,8 +128,8 @@ each run. ``Simulator`` now accepts ``flora_mode=True`` which enables the
 official detection threshold, interference window and a ``flora`` propagation
   profile. Pass the `--flora-csv <file>` option to automatically compare these
   metrics with an official FLoRa export using `compare_with_sim`. FLoRa stores
-  its results in `.sca` and `.vec` files. You may convert them to CSV with
-  external tools if needed.
+  its results in `.sca` and `.vec` files. Use `tools/convert_flora_results.py`
+  to turn these into CSV files if needed.
 Passing `--degrade` to the script enables a harsh propagation profile that
 significantly lowers the Packet Delivery Ratio.  Additional interference,
 stronger fast fading and a higher path loss exponent are applied together with a
@@ -233,13 +233,14 @@ The tests compare RSSI and airtime calculations against theoretical values and c
 ### Cross-check with FLoRa
 
   The module `VERSION_4/launcher/compare_flora.py` can read exports from
-  the FLoRa simulator (typically `.sca`/`.vec` files converted to CSV) and extracts several metrics: Packet Delivery Ratio,
+  the FLoRa simulator. It accepts raw `.sca` result files or CSV files produced
+  with `tools/convert_flora_results.py` and extracts several metrics: Packet Delivery Ratio,
 spreading factor histogram, energy consumption, throughput and packet
 collisions.  The test file `tests/test_flora_comparison.py` demonstrates
 how to compare these values with those returned by
 `Simulator.get_metrics` to validate the Python implementation against
 OMNeT++ runs.
-  You can also supply a reference CSV (converted from `.sca`/`.vec`) to
+  You can also supply a reference CSV or a directory containing `.sca` files to
   `examples/run_flora_example.py` via `--flora-csv` to perform this check outside
   the test suite.
 
@@ -261,7 +262,8 @@ the current directory.
 
   The script `tools/calibrate_flora.py` automates the search of channel
   parameters that best reproduce a reference export from FLoRa. The reference
-  data should come from FLoRa `.sca`/`.vec` results converted to CSV. It launches
+  data should come from FLoRa results converted to CSV with
+  `tools/convert_flora_results.py`. It launches
   several runs with different propagation settings and reports the combination
   yielding the smallest PDR difference. From the repository root run:
 

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/compare_flora.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/compare_flora.py
@@ -8,8 +8,12 @@ from typing import Any
 import pandas as pd
 
 
-def _load_sca_file(path: Path) -> dict[str, Any]:
-    """Parse a minimal OMNeT++ .sca result file."""
+def _parse_sca_file(path: Path) -> dict[str, Any]:
+    """Return raw metrics from an OMNeT++ ``.sca`` file.
+
+    The resulting dictionary can be converted to a DataFrame to compute
+    aggregates similar to a FLoRa CSV export.
+    """
     metrics: dict[str, float] = {}
     with open(path, "r") as f:
         for line in f:
@@ -22,24 +26,62 @@ def _load_sca_file(path: Path) -> dict[str, Any]:
                     continue
                 metrics[name] = metrics.get(name, 0.0) + value
 
-    total_sent = int(metrics.get("sent", 0))
-    total_recv = int(metrics.get("received", 0))
+    row: dict[str, Any] = {}
+    for key, val in metrics.items():
+        if key in {"sent", "received", "collisions"}:
+            row[key] = int(val)
+        elif key in {"throughput_bps", "energy_J", "energy", "rssi", "snr"}:
+            row[key] = float(val)
+        elif key.startswith("sf") and key[2:].isdigit():
+            row[key] = int(val)
+        elif key.startswith("collisions_sf"):
+            row[key] = int(val)
+
+    return row
+
+
+def _aggregate_df(df: pd.DataFrame) -> dict[str, Any]:
+    """Compute aggregated metrics from a DataFrame of raw values."""
+    total_sent = int(df["sent"].sum()) if "sent" in df.columns else 0
+    total_recv = int(df["received"].sum()) if "received" in df.columns else 0
     pdr = total_recv / total_sent if total_sent else 0.0
-    sf_hist = {int(k[2:]): int(v) for k, v in metrics.items() if k.startswith("sf")}
-    collisions = int(metrics.get("collisions", 0))
-    coll_dist = {
-        int(k.split("sf")[1]): int(v)
-        for k, v in metrics.items()
-        if k.startswith("collisions_sf")
-    }
+
+    sf_cols = [
+        c
+        for c in df.columns
+        if c.startswith("sf") and not c.startswith("collisions_sf")
+    ]
+    sf_hist = {int(c[2:]): int(df[c].sum()) for c in sf_cols}
+
+    throughput = (
+        float(df["throughput_bps"].mean()) if "throughput_bps" in df.columns else 0.0
+    )
+    if "energy_J" in df.columns:
+        energy = float(df["energy_J"].mean())
+    elif "energy" in df.columns:
+        energy = float(df["energy"].mean())
+    else:
+        energy = 0.0
+
+    collisions = int(df["collisions"].sum()) if "collisions" in df.columns else 0
+    collision_cols = [c for c in df.columns if c.startswith("collisions_sf")]
+    collision_dist = {int(c.split("sf")[1]): int(df[c].sum()) for c in collision_cols}
+
     return {
         "PDR": pdr,
         "sf_distribution": sf_hist,
-        "throughput_bps": float(metrics.get("throughput_bps", 0)),
-        "energy_J": float(metrics.get("energy_J", metrics.get("energy", 0))),
-        "collision_distribution": coll_dist,
+        "throughput_bps": throughput,
+        "energy_J": energy,
+        "collision_distribution": collision_dist,
         "collisions": collisions,
     }
+
+
+def _load_sca_file(path: Path) -> dict[str, Any]:
+    """Parse a single ``.sca`` file and compute aggregated metrics."""
+    row = _parse_sca_file(path)
+    df = pd.DataFrame([row])
+    return _aggregate_df(df)
 
 
 def load_flora_metrics(path: str | Path) -> dict[str, Any]:
@@ -61,6 +103,11 @@ def load_flora_metrics(path: str | Path) -> dict[str, Any]:
         Number of collisions that occurred with spreading factor ``X``.
     """
     path = Path(path)
+    if path.is_dir():
+        rows = [_parse_sca_file(p) for p in sorted(path.glob("*.sca"))]
+        df = pd.DataFrame(rows)
+        return _aggregate_df(df)
+
     if path.suffix.lower() == ".sca":
         return _load_sca_file(path)
 
@@ -68,10 +115,16 @@ def load_flora_metrics(path: str | Path) -> dict[str, Any]:
     total_sent = int(df["sent"].sum()) if "sent" in df.columns else 0
     total_recv = int(df["received"].sum()) if "received" in df.columns else 0
     pdr = total_recv / total_sent if total_sent else 0.0
-    sf_cols = [c for c in df.columns if c.startswith("sf") and not c.startswith("sf_collisions")]
+    sf_cols = [
+        c
+        for c in df.columns
+        if c.startswith("sf") and not c.startswith("sf_collisions")
+    ]
     sf_hist = {int(c[2:]): int(df[c].sum()) for c in sf_cols}
 
-    throughput = float(df["throughput_bps"].mean()) if "throughput_bps" in df.columns else 0.0
+    throughput = (
+        float(df["throughput_bps"].mean()) if "throughput_bps" in df.columns else 0.0
+    )
     if "energy_J" in df.columns:
         energy = float(df["energy_J"].mean())
     elif "energy" in df.columns:
@@ -94,7 +147,9 @@ def load_flora_metrics(path: str | Path) -> dict[str, Any]:
     }
 
 
-def compare_with_sim(sim_metrics: dict[str, Any], flora_csv: str | Path, *, pdr_tol: float = 0.05) -> bool:
+def compare_with_sim(
+    sim_metrics: dict[str, Any], flora_csv: str | Path, *, pdr_tol: float = 0.05
+) -> bool:
     """Compare simulator metrics with FLoRa results.
 
     Parameters
@@ -120,15 +175,14 @@ def compare_with_sim(sim_metrics: dict[str, Any], flora_csv: str | Path, *, pdr_
 def load_flora_rx_stats(path: str | Path) -> dict[str, Any]:
     """Load average RSSI/SNR and collisions from a FLoRa export."""
     path = Path(path)
-    if path.suffix.lower() == ".sca":
-        data = _load_sca_file(path)
-        return {
-            "rssi": data.get("rssi", 0.0),
-            "snr": data.get("snr", 0.0),
-            "collisions": data.get("collisions", 0),
-        }
+    if path.is_dir():
+        rows = [_parse_sca_file(p) for p in sorted(path.glob("*.sca"))]
+        df = pd.DataFrame(rows)
+    elif path.suffix.lower() == ".sca":
+        df = pd.DataFrame([_parse_sca_file(path)])
+    else:
+        df = pd.read_csv(path)
 
-    df = pd.read_csv(path)
     rssi = float(df["rssi"].mean()) if "rssi" in df.columns else 0.0
     snr = float(df["snr"].mean()) if "snr" in df.columns else 0.0
     collisions = int(df["collisions"].sum()) if "collisions" in df.columns else 0

--- a/simulateur_lora_sfrd_4.0/tools/convert_flora_results.py
+++ b/simulateur_lora_sfrd_4.0/tools/convert_flora_results.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Convert FLoRa OMNeT++ results to CSV."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import pandas as pd
+
+from VERSION_4.launcher.compare_flora import _parse_sca_file
+
+
+def gather_sca_files(paths: list[str | Path]) -> list[Path]:
+    files: list[Path] = []
+    for p in paths:
+        path = Path(p)
+        if path.is_dir():
+            files.extend(sorted(path.glob("*.sca")))
+        elif path.suffix.lower() == ".sca":
+            files.append(path)
+    return files
+
+
+def convert(paths: list[str | Path], output: str | Path) -> None:
+    files = gather_sca_files(paths)
+    rows = []
+    for idx, sca in enumerate(files, start=1):
+        row = _parse_sca_file(sca)
+        row["run"] = idx
+        rows.append(row)
+    df = pd.DataFrame(rows)
+    df.to_csv(output, index=False)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Convert FLoRa .sca/.vec to CSV")
+    parser.add_argument("results", nargs="+", help=".sca files or directories")
+    parser.add_argument("--output", "-o", default="flora.csv", help="Output CSV file")
+    args = parser.parse_args()
+    convert(args.results, args.output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `tools/convert_flora_results.py` to convert OMNeT++ `.sca` outputs to CSV
- allow directories or raw `.sca` files in `load_flora_metrics` and `load_flora_rx_stats`
- document the converter in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cef5f5e3083318ae6a4eb2e684980