### PR TITLE
Implement join server module

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/join_server.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/join_server.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class JoinServer:
+    """Minimal OTAA join server handling MIC validation and key derivation."""
+
+    net_id: int = 0
+    devices: dict[tuple[int, int], bytes] = field(default_factory=dict)
+    last_devnonce: dict[tuple[int, int], int] = field(default_factory=dict)
+    next_devaddr: int = 1
+    app_nonce: int = 1
+
+    def register(self, join_eui: int, dev_eui: int, app_key: bytes) -> None:
+        """Register a device and its AppKey."""
+        if len(app_key) != 16:
+            raise ValueError("Invalid AppKey")
+        self.devices[(join_eui, dev_eui)] = app_key
+
+    def handle_join(self, req: "JoinRequest") -> tuple["JoinAccept", bytes, bytes]:
+        """Validate ``req`` and return a join-accept frame with session keys."""
+        from .lorawan import (
+            compute_join_mic,
+            derive_session_keys,
+            aes_decrypt,
+            JoinAccept,
+        )
+
+        key = (req.join_eui, req.dev_eui)
+        app_key = self.devices.get(key)
+        if app_key is None:
+            raise KeyError("Unknown device")
+
+        if compute_join_mic(app_key, req.to_bytes()) != req.mic:
+            raise ValueError("Invalid MIC")
+
+        last = self.last_devnonce.get(key)
+        if last is not None and req.dev_nonce <= last:
+            raise ValueError("DevNonce reused")
+        self.last_devnonce[key] = req.dev_nonce
+
+        app_nonce = self.app_nonce & 0xFFFFFF
+        self.app_nonce += 1
+        dev_addr = self.next_devaddr
+        self.next_devaddr += 1
+
+        nwk_skey, app_skey = derive_session_keys(
+            app_key, req.dev_nonce, app_nonce, self.net_id
+        )
+
+        accept = JoinAccept(app_nonce, self.net_id, dev_addr)
+        msg = accept.to_bytes()
+        pad = (16 - len(msg) % 16) % 16
+        accept.encrypted = aes_decrypt(app_key, msg + bytes(pad))
+        accept.mic = compute_join_mic(app_key, msg)
+        return accept, nwk_skey, app_skey


### PR DESCRIPTION
## Summary
- add `join_server` module to manage OTAA activations
- refactor `server.py` to import the new module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cef6a76d88331b51a6dd13bc7ee26