### PR TITLE
Fix missing path_index initialization

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/node.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/node.py
@@ -133,6 +133,8 @@ class Node:
         self.path = None
         self.path_progress = 0.0
         self.path_duration = 0.0
+        # Index du prochain point sur le chemin (pour PathMobility)
+        self.path_index = 0
 
         # LoRaWAN specific parameters
         self.activated = activated


### PR DESCRIPTION
## Summary
- initialize `Node.path_index` so path-based mobility doesn't rely on dynamic attributes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687cf5b62f98833194f4c7d626b80cd9