### PR TITLE
Ajustement modéré du canal ADR1

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/README.md
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/README.md
@@ -297,7 +297,7 @@ paramètre `fast_fading_std` afin de simuler un canal multipath et utiliser
 
 To reproduce FLoRa INI scenarios:
 1. Pass `flora_mode=True` when creating the `Simulator` (or enable **Mode FLoRa complet**). This applies the official `-110 dBm` detection threshold and a `5 s` interference window.
-2. Apply the ADR1 algorithm with `from VERSION_4.launcher.adr_standard_1 import apply as adr1` then `adr1(sim)`. This preset mirrors the ADR logic of the original FLoRa server (SNR history, margin and multi‑step adjustments). Using `degrade_channel=True` now applies even stronger propagation impairments to rapidly lower the PDR.
+2. Apply the ADR1 algorithm with `from VERSION_4.launcher.adr_standard_1 import apply as adr1` then `adr1(sim)`. This preset mirrors the ADR logic of the original FLoRa server (SNR history, margin and multi‑step adjustments). Using `degrade_channel=True` now applies moderate propagation impairments to gently reduce the PDR.
 3. Provide the INI file path to `Simulator(config_file=...)` or use **Positions manuelles** to enter the coordinates manually.
 4. Fill in **Graine** to keep the exact placement across runs.
 5. Or run `python examples/run_flora_example.py` which combines these settings.

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/adr_standard_1.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/adr_standard_1.py
@@ -35,16 +35,16 @@ def apply(sim: Simulator, *, degrade_channel: bool = False) -> None:
         for ch in sim.multichannel.channels:
             base = ch.base if isinstance(ch, AdvancedChannel) else ch
             # Apply moderate interference instead of the previous harsh value
-            base.interference_dB = max(base.interference_dB, 10.0)
+            base.interference_dB = max(base.interference_dB, 8.0)
             # Reduce the fast fading amplitude
-            base.fast_fading_std = max(base.fast_fading_std, 6.0)
+            base.fast_fading_std = max(base.fast_fading_std, 5.0)
             # Slightly increase the path loss exponent
-            base.path_loss_exp = max(base.path_loss_exp, 3.3)
+            base.path_loss_exp = max(base.path_loss_exp, 3.2)
             # Keep a detection threshold closer to nominal sensitivity
-            base.detection_threshold_dBm = max(base.detection_threshold_dBm, -90.0)
+            base.detection_threshold_dBm = max(base.detection_threshold_dBm, -92.0)
             # Limit slow varying noise
-            base.noise_floor_std = max(base.noise_floor_std, 1.5)
+            base.noise_floor_std = max(base.noise_floor_std, 1.0)
             if isinstance(ch, AdvancedChannel):
                 ch.fading = "rayleigh"
-                ch.weather_loss_dB_per_km = max(ch.weather_loss_dB_per_km, 1.0)
-        sim.detection_threshold_dBm = -90.0
+                ch.weather_loss_dB_per_km = max(ch.weather_loss_dB_per_km, 0.8)
+        sim.detection_threshold_dBm = -92.0


### PR DESCRIPTION
## Summary
- réduit un peu les pénalités appliquées avec `degrade_channel=True`
- mentionne un impact plus modéré dans la documentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d0f06840c833182887e366f139b58