### PR TITLE
Fix README bullet formatting

### DIFF
--- a/simulateur_lora_sfrd_4.0/README.md
+++ b/simulateur_lora_sfrd_4.0/README.md
@@ -309,8 +309,7 @@ This project is licensed under the [MIT License](LICENSE).
 
 ## Current limitations
 
--This simulator aims to remain lightweight and therefore omits several advanced
-concepts:
+- This simulator aims to remain lightweight and therefore omits several advanced concepts:
 
 - The physical layer is greatly simplified and does not reproduce hardware
   imperfections found in real devices.


### PR DESCRIPTION
## Summary
- fix the missing space before the bullet under `Current limitations`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d1e723c5c833192220ea53a0c8b6a