### PR TITLE
feat: strengthen OTAA security checks

### DIFF
--- a/simulateur_lora_sfrd_4.0/tests/test_otaa.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_otaa.py
@@ -8,7 +8,12 @@ from VERSION_4.launcher.node import Node  # noqa: E402
 from VERSION_4.launcher.gateway import Gateway  # noqa: E402
 from VERSION_4.launcher.channel import Channel  # noqa: E402
 from VERSION_4.launcher.server import NetworkServer, JoinServer  # noqa: E402
-from VERSION_4.launcher.lorawan import JoinRequest, JoinAccept  # noqa: E402
+from VERSION_4.launcher.lorawan import (
+    JoinRequest,
+    JoinAccept,
+    compute_join_mic,
+    aes_encrypt,
+)  # noqa: E402
 
 
 def test_otaa_join_procedure():
@@ -22,13 +27,20 @@ def test_otaa_join_procedure():
 
     req = node.prepare_uplink(b"")
     assert isinstance(req, JoinRequest)
+    assert compute_join_mic(node.appkey, req.to_bytes()) == req.mic
 
     ns.receive(event_id=1, node_id=node.id, gateway_id=gw.id, frame=req)
     frame = gw.pop_downlink(node.id)
     assert isinstance(frame, JoinAccept)
+    assert compute_join_mic(node.appkey, frame.to_bytes()) == frame.mic
+    assert aes_encrypt(node.appkey, frame.encrypted)[:10] == frame.to_bytes()
 
     node.handle_downlink(frame)
     assert node.activated
     assert len(node.nwkskey) == 16
     assert len(node.appskey) == 16
     assert node.downlink_pending == 0
+    assert js.get_session_keys(node.join_eui, node.dev_eui) == (
+        node.nwkskey,
+        node.appskey,
+    )


### PR DESCRIPTION
## Summary
- store session keys in join server
- add LoRaWAN encrypt/decrypt helpers
- test full OTAA join cycle including MIC checks

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687eab92bde88331bc2dea08d2994ef3