### PR TITLE
Add FLoRa delay & energy class metrics

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/simulator.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/simulator.py
@@ -897,6 +897,11 @@ class Simulator:
             delivered_cls = sum(n.packets_success for n in nodes_cls)
             pdr_by_class[ct] = delivered_cls / sent_cls if sent_cls > 0 else 0.0
 
+        energy_by_class = {
+            ct: sum(n.energy_consumed for n in self.nodes if n.class_type == ct)
+            for ct in class_types
+        }
+
         return {
             'PDR': pdr,
             'collisions': self.packets_lost_collision,
@@ -909,6 +914,7 @@ class Simulator:
             'pdr_by_sf': pdr_by_sf,
             'pdr_by_gateway': pdr_by_gateway,
             'pdr_by_class': pdr_by_class,
+            **{f"energy_class_{ct}_J": energy_by_class[ct] for ct in energy_by_class},
             'retransmissions': self.retransmissions,
         }
 

--- a/simulateur_lora_sfrd_4.0/examples/compare_multi_metrics.py
+++ b/simulateur_lora_sfrd_4.0/examples/compare_multi_metrics.py
@@ -1,0 +1,26 @@
+"""Exemple de comparaison multi-critères avec un export FLoRa."""
+import argparse
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from tools.compare_flora_report import generate_report  # noqa: E402
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Compare run.py results with FLoRa reference")
+    parser.add_argument("flora_csv", help="CSV exporté depuis FLoRa")
+    parser.add_argument("sim_csv", help="CSV généré par run.py")
+    parser.add_argument(
+        "--output-prefix",
+        default="comparison",
+        help="Préfixe des fichiers de sortie (par défaut: comparison)",
+    )
+    args = parser.parse_args()
+    generate_report(args.flora_csv, args.sim_csv, output_prefix=args.output_prefix)
+
+
+if __name__ == "__main__":
+    main()

--- a/simulateur_lora_sfrd_4.0/examples/flora_collisions.csv
+++ b/simulateur_lora_sfrd_4.0/examples/flora_collisions.csv
@@ -1,2 +1,2 @@
-run,sent,received,collisions,energy_J,throughput_bps,sf7,sf8,sf9,sf10,sf11,sf12,collisions_sf7,collisions_sf8,collisions_sf9,collisions_sf10,collisions_sf11,collisions_sf12
-1,2,0,2,0.0224,0.0,2,0,0,0,0,0,2,0,0,0,0,0
+run,sent,received,collisions,energy_J,throughput_bps,avg_delay_s,energy_class_A_J,sf7,sf8,sf9,sf10,sf11,sf12,collisions_sf7,collisions_sf8,collisions_sf9,collisions_sf10,collisions_sf11,collisions_sf12
+1,2,0,2,0.0224,0.0,0.0,0.0224,2,0,0,0,0,0,2,0,0,0,0,0

--- a/simulateur_lora_sfrd_4.0/examples/flora_full.csv
+++ b/simulateur_lora_sfrd_4.0/examples/flora_full.csv
@@ -1,2 +1,2 @@
-run,sent,received,collisions,energy_J,throughput_bps,sf7,sf8,sf9,sf10,sf11,sf12,collisions_sf7,collisions_sf8,collisions_sf9,collisions_sf10,collisions_sf11,collisions_sf12
-1,2,2,0,0.0224,104.69,2,0,0,0,0,0,0,0,0,0,0,0
+run,sent,received,collisions,energy_J,throughput_bps,avg_delay_s,energy_class_A_J,sf7,sf8,sf9,sf10,sf11,sf12,collisions_sf7,collisions_sf8,collisions_sf9,collisions_sf10,collisions_sf11,collisions_sf12
+1,2,2,0,0.0224,104.69,0.0566,0.0224,2,0,0,0,0,0,0,0,0,0,0,0

--- a/simulateur_lora_sfrd_4.0/tests/data/flora_collisions.csv
+++ b/simulateur_lora_sfrd_4.0/tests/data/flora_collisions.csv
@@ -1,2 +1,2 @@
-run,sent,received,collisions,energy_J,throughput_bps,sf7,sf8,sf9,sf10,sf11,sf12,collisions_sf7,collisions_sf8,collisions_sf9,collisions_sf10,collisions_sf11,collisions_sf12
-1,2,0,2,0.0224,0.0,2,0,0,0,0,0,2,0,0,0,0,0
+run,sent,received,collisions,energy_J,throughput_bps,avg_delay_s,energy_class_A_J,sf7,sf8,sf9,sf10,sf11,sf12,collisions_sf7,collisions_sf8,collisions_sf9,collisions_sf10,collisions_sf11,collisions_sf12
+1,2,0,2,0.0224,0.0,0.0,0.0224,2,0,0,0,0,0,2,0,0,0,0,0

--- a/simulateur_lora_sfrd_4.0/tests/data/flora_full.csv
+++ b/simulateur_lora_sfrd_4.0/tests/data/flora_full.csv
@@ -1,2 +1,2 @@
-run,sent,received,collisions,energy_J,throughput_bps,sf7,sf8,sf9,sf10,sf11,sf12,collisions_sf7,collisions_sf8,collisions_sf9,collisions_sf10,collisions_sf11,collisions_sf12
-1,2,2,0,0.0224,104.69,2,0,0,0,0,0,0,0,0,0,0,0
+run,sent,received,collisions,energy_J,throughput_bps,avg_delay_s,energy_class_A_J,sf7,sf8,sf9,sf10,sf11,sf12,collisions_sf7,collisions_sf8,collisions_sf9,collisions_sf10,collisions_sf11,collisions_sf12
+1,2,2,0,0.0224,104.69,0.0566,0.0224,2,0,0,0,0,0,0,0,0,0,0,0

--- a/simulateur_lora_sfrd_4.0/tests/test_flora_comparison.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_flora_comparison.py
@@ -83,6 +83,11 @@ def test_compare_with_flora_sample(csv_file: str, num_nodes: int) -> None:
 
     assert metrics["PDR"] == pytest.approx(flora_metrics["PDR"], abs=0.01)
     assert metrics["sf_distribution"] == flora_metrics["sf_distribution"]
+    if "avg_delay_s" in flora_metrics:
+        assert metrics["avg_delay_s"] == pytest.approx(flora_metrics["avg_delay_s"], abs=1e-3)
+    for key in flora_metrics:
+        if key.startswith("energy_class_"):
+            assert metrics[key] == pytest.approx(flora_metrics[key], abs=1e-4)
     assert compare_with_sim(metrics, flora_csv)
 
 
@@ -90,9 +95,15 @@ def test_collision_distribution_against_flora():
     sim = _make_colliding_sim()
     while sim.step():
         pass
+    metrics = sim.get_metrics()
     flora_csv = Path(__file__).parent / "data" / "flora_collisions.csv"
     flora_metrics = load_flora_metrics(flora_csv)
     sim_cd = {7: sum(n.packets_collision for n in sim.nodes if n.sf == 7)}
     assert sim.packets_lost_collision == flora_metrics["collisions"]
     assert sim.packets_lost_collision == sum(flora_metrics["collision_distribution"].values())
     assert sim_cd == flora_metrics["collision_distribution"]
+    if "avg_delay_s" in flora_metrics:
+        assert metrics["avg_delay_s"] == pytest.approx(flora_metrics["avg_delay_s"], abs=1e-3)
+    for key in flora_metrics:
+        if key.startswith("energy_class_"):
+            assert metrics[key] == pytest.approx(flora_metrics[key], abs=1e-4)

--- a/simulateur_lora_sfrd_4.0/tools/compare_flora_report.py
+++ b/simulateur_lora_sfrd_4.0/tools/compare_flora_report.py
@@ -23,6 +23,7 @@ def load_run_metrics(csv_path: str | Path) -> dict[str, float]:
         "throughput_bps",
         "energy_J",
         "energy",
+        "avg_delay",
     ]:
         if col in df.columns:
             df[col] = pd.to_numeric(df[col], errors="coerce")
@@ -40,6 +41,11 @@ def load_run_metrics(csv_path: str | Path) -> dict[str, float]:
         metrics["energy_J"] = df["energy_J"].mean()
     elif "energy" in df.columns:
         metrics["energy_J"] = df["energy"].mean()
+    if "avg_delay" in df.columns:
+        metrics["avg_delay_s"] = df["avg_delay"].mean()
+    for col in df.columns:
+        if col.startswith("energy_class_"):
+            metrics[col] = df[col].mean()
 
     return metrics
 
@@ -50,7 +56,9 @@ def generate_report(
     flora = load_flora_metrics(flora_csv)
     sim = load_run_metrics(sim_csv)
 
-    metrics = ["PDR", "collisions", "throughput_bps", "energy_J"]
+    metrics = ["PDR", "collisions", "throughput_bps", "avg_delay_s", "energy_J"]
+    class_metrics = [k for k in sorted(set(flora) | set(sim)) if k.startswith("energy_class_")]
+    metrics.extend(class_metrics)
     rows = []
     for m in metrics:
         flora_val = flora.get(m, 0)


### PR DESCRIPTION
## Summary
- support `avg_delay_s` and `energy_class_*_J` when loading FLoRa CSV
- expose energy consumption per class in simulator metrics
- update comparison report utility and add `compare_multi_metrics.py` example
- extend FLoRa CSV samples with delay and energy class values
- test new metrics in `test_flora_comparison`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eaba37a2c8331bc98eec670744f21