### PR TITLE
Add phase noise and PA non-linearity options

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/README.md
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/README.md
@@ -168,6 +168,10 @@ réception :
 - `noise_figure` : facteur de bruit du récepteur en dB.
 - `noise_floor_std` : écart-type de la variation aléatoire du bruit (dB).
 - `fast_fading_std` : amplitude du fading multipath en dB.
+- `temperature_std_K` : variation de température pour le calcul du bruit.
+- `pa_non_linearity_dB` / `pa_non_linearity_std_dB` : modélisent la
+  non‑linéarité de l'amplificateur de puissance.
+- `phase_noise_std_dB` : bruit de phase ajouté au SNR.
 - `environment` : preset rapide pour le modèle de propagation
   (`urban`, `suburban` ou `rural` ou `flora`).
 

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/omnet_phy.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/omnet_phy.py
@@ -36,6 +36,7 @@ class OmnetPHY:
         temperature_std_K: float = 0.0,
         pa_non_linearity_dB: float = 0.0,
         pa_non_linearity_std_dB: float = 0.0,
+        phase_noise_std_dB: float = 0.0,
     ) -> None:
         self.channel = channel
         self.model = OmnetModel(
@@ -62,6 +63,7 @@ class OmnetPHY:
             pa_non_linearity_std_dB,
             corr,
         )
+        self._phase_noise = _CorrelatedValue(0.0, phase_noise_std_dB, corr)
 
     # ------------------------------------------------------------------
     def path_loss(self, distance: float) -> float:
@@ -134,6 +136,7 @@ class OmnetPHY:
         snr = rssi - self.noise_floor() + ch.snr_offset_dB
         penalty = self._alignment_penalty_db(freq_offset_hz, sync_offset_s, sf)
         snr -= penalty
+        snr -= abs(self._phase_noise.sample())
         if sf is not None:
             snr += 10 * math.log10(2 ** sf)
         return rssi, snr

--- a/simulateur_lora_sfrd_4.0/tests/test_advanced_channel.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_advanced_channel.py
@@ -142,3 +142,11 @@ def test_pa_non_linearity():
     r1, _ = adv.compute_rssi(14.0, 100.0)
     r2, _ = adv.compute_rssi(14.0, 100.0)
     assert r1 != r2
+
+
+def test_phase_noise_penalizes_snr():
+    random.seed(0)
+    adv = AdvancedChannel(fading="", shadowing_std=0, phase_noise_std_dB=2.0)
+    _, snr1 = adv.compute_rssi(14.0, 100.0)
+    _, snr2 = adv.compute_rssi(14.0, 100.0)
+    assert snr1 != snr2

--- a/simulateur_lora_sfrd_4.0/tests/test_channel.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_channel.py
@@ -6,6 +6,7 @@ sys.path.insert(0, str(ROOT))
 
 from VERSION_4.launcher.channel import Channel  # noqa: E402
 import pytest  # noqa: E402
+import random
 
 
 def test_environment_preset_values():
@@ -62,3 +63,27 @@ def test_offsets_and_system_loss():
     r2, s2 = mod.compute_rssi(14.0, 100.0, sf=7)
     assert r2 == pytest.approx(r1 - 2.0 + 3.0)
     assert s2 == pytest.approx(s1 - 2.0 + 3.0 + 1.0)
+
+
+def test_temperature_variation_changes_snr():
+    random.seed(0)
+    ch = Channel(shadowing_std=0, temperature_std_K=20.0)
+    _, snr1 = ch.compute_rssi(14.0, 100.0)
+    _, snr2 = ch.compute_rssi(14.0, 100.0)
+    assert snr1 != snr2
+
+
+def test_pa_non_linearity_channel():
+    random.seed(0)
+    ch = Channel(shadowing_std=0, pa_non_linearity_std_dB=1.0)
+    r1, _ = ch.compute_rssi(14.0, 100.0)
+    r2, _ = ch.compute_rssi(14.0, 100.0)
+    assert r1 != r2
+
+
+def test_phase_noise_channel():
+    random.seed(0)
+    ch = Channel(shadowing_std=0, phase_noise_std_dB=2.0)
+    _, snr1 = ch.compute_rssi(14.0, 100.0)
+    _, snr2 = ch.compute_rssi(14.0, 100.0)
+    assert snr1 != snr2

--- a/simulateur_lora_sfrd_4.0/tests/test_omnet_phy.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_omnet_phy.py
@@ -71,6 +71,7 @@ def test_device_specific_features_in_phy():
         dev_freq_offset_std_hz=100.0,
         temperature_std_K=20.0,
         pa_non_linearity_std_dB=1.0,
+        phase_noise_std_dB=2.0,
     )
     r1, _ = ch.omnet_phy.compute_rssi(14.0, 100.0)
     r2, _ = ch.omnet_phy.compute_rssi(14.0, 100.0)


### PR DESCRIPTION
## Summary
- extend Channel to simulate temperature variation, PA non‑linearity and phase noise
- propagate these options to OmnetPHY and AdvancedChannel
- document new parameters in README
- add tests for the new impairments

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eab99b5308331891adeb775b7e2f4