### PR TITLE
Simulate beacon loss and clock drift

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/downlink_scheduler.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/downlink_scheduler.py
@@ -42,11 +42,17 @@ class DownlinkScheduler:
         beacon_interval: float,
         ping_slot_interval: float,
         ping_slot_offset: float,
+        *,
+        last_beacon_time: float | None = None,
     ) -> float:
         """Schedule ``frame`` for ``node`` at its next ping slot."""
         duration = node.channel.airtime(node.sf, self._payload_length(frame))
         t = node.next_ping_slot_time(
-            after_time, beacon_interval, ping_slot_interval, ping_slot_offset
+            after_time,
+            beacon_interval,
+            ping_slot_interval,
+            ping_slot_offset,
+            last_beacon_time=last_beacon_time,
         )
         busy = self._gateway_busy.get(gateway.id, 0.0)
         if t < busy:

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/simulator.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/simulator.py
@@ -240,6 +240,8 @@ class Simulator:
         self.network_server = NetworkServer()
         self.network_server.beacon_interval = self.beacon_interval
         self.network_server.beacon_drift = self.beacon_drift
+        self.network_server.ping_slot_interval = self.ping_slot_interval
+        self.network_server.ping_slot_offset = self.ping_slot_offset
 
         # Graine utilisée uniquement pour le placement initial des entités
         self.seed = seed
@@ -749,6 +751,9 @@ class Simulator:
                     received = random.random() >= getattr(n, "beacon_loss_prob", 0.0)
                     if received:
                         n.last_beacon_time = time
+                        n.clock_offset = 0.0
+                    else:
+                        n.miss_beacon(self.beacon_interval)
                     periodicity = 2 ** (getattr(n, "ping_slot_periodicity", 0) or 0)
                     interval = self.ping_slot_interval * periodicity
                     slot = n.next_ping_slot_time(


### PR DESCRIPTION
## Summary
- add clock offset tracking to nodes and expose `miss_beacon`
- make network server aware of ping-slot timing parameters
- resynchronise downlinks when a ping slot was missed
- propagate beacon loss in simulator
- test rescheduling on missed beacon and RX window timing

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eab8cb25c833188dd82e98ffdb13e