### PR TITLE
Add selective interference bands

### DIFF
--- a/simulateur_lora_sfrd_4.0/README.md
+++ b/simulateur_lora_sfrd_4.0/README.md
@@ -17,6 +17,7 @@ This repository contains a lightweight LoRa network simulator implemented in Pyt
   `AdvancedChannel`
 - Terrain and weather based attenuation parameters
 - Time‑varying frequency and synchronisation offsets for realistic collisions
+- Optional frequency‑selective interference bands for jamming scenarios
 - Configurable bandwidth and coding rate per channel
 - Preset propagation environments (urban/suburban/rural) for quick channel setup
 - Capture effect and a minimum interference time to ignore very short overlaps

--- a/simulateur_lora_sfrd_4.0/VERSION_4/README.md
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/README.md
@@ -172,6 +172,8 @@ réception :
 - `pa_non_linearity_dB` / `pa_non_linearity_std_dB` : modélisent la
   non‑linéarité de l'amplificateur de puissance.
 - `phase_noise_std_dB` : bruit de phase ajouté au SNR.
+- `band_interference` : liste de brouilleurs sélectifs sous la forme
+  `(freq, bw, dB)` appliqués au calcul du bruit.
 - `environment` : preset rapide pour le modèle de propagation
   (`urban`, `suburban` ou `rural` ou `flora`).
 

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/omnet_phy.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/omnet_phy.py
@@ -87,6 +87,10 @@ class OmnetPHY:
         else:
             thermal = self.model.thermal_noise_dBm(ch.bandwidth)
         noise = thermal + ch.noise_figure_dB + ch.interference_dB
+        for f, bw, power in ch.band_interference:
+            half = (bw + ch.bandwidth) / 2.0
+            if abs(ch.frequency_hz - f) <= half:
+                noise += power
         if ch.noise_floor_std > 0:
             noise += random.gauss(0.0, ch.noise_floor_std)
         noise += self.model.noise_variation()

--- a/simulateur_lora_sfrd_4.0/tests/test_channel.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_channel.py
@@ -87,3 +87,15 @@ def test_phase_noise_channel():
     _, snr1 = ch.compute_rssi(14.0, 100.0)
     _, snr2 = ch.compute_rssi(14.0, 100.0)
     assert snr1 != snr2
+
+
+def test_band_interference_degrades_snr():
+    random.seed(0)
+    base = Channel(shadowing_std=0)
+    jam = Channel(
+        shadowing_std=0,
+        band_interference=[(base.frequency_hz, base.bandwidth, 10.0)],
+    )
+    _, snr_base = base.compute_rssi(14.0, 100.0)
+    _, snr_jam = jam.compute_rssi(14.0, 100.0)
+    assert snr_jam < snr_base


### PR DESCRIPTION
## Summary
- introduce band_interference for frequency-selective jamming
- document the new option
- support interference bands in OmnetPHY
- test that interference degrades SNR

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eaf20dbcc83319e3c11cce97c70aa