### PR TITLE
Add humidity-based noise modelling

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/README.md
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/README.md
@@ -169,6 +169,9 @@ réception :
 - `noise_floor_std` : écart-type de la variation aléatoire du bruit (dB).
 - `fast_fading_std` : amplitude du fading multipath en dB.
 - `temperature_std_K` : variation de température pour le calcul du bruit.
+- `humidity_percent` et `humidity_noise_coeff_dB` : ajoutent un bruit
+  supplémentaire proportionnel à l'humidité relative. La variation temporelle
+  peut être définie via `humidity_std_percent`.
 - `pa_non_linearity_dB` / `pa_non_linearity_std_dB` : modélisent la
   non‑linéarité de l'amplificateur de puissance.
 - `phase_noise_std_dB` : bruit de phase ajouté au SNR.
@@ -208,7 +211,9 @@ possible de simuler un fading `rayleigh` ou `rician` pour représenter des
 multi-trajets plus réalistes. Des gains d'antenne et pertes de câble
 peuvent être précisés, ainsi qu'une variation temporelle du bruit grâce
 à `noise_floor_std`. Des pertes liées aux conditions météo peuvent être
-ajoutées via `weather_loss_dB_per_km`.
+ajoutées via `weather_loss_dB_per_km`. Un bruit supplémentaire dépendant
+de l'humidité peut également être activé grâce aux paramètres
+`humidity_percent` et `humidity_noise_coeff_dB`.
 
 ```python
 from launcher.advanced_channel import AdvancedChannel

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/omnet_phy.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/omnet_phy.py
@@ -87,6 +87,8 @@ class OmnetPHY:
         else:
             thermal = self.model.thermal_noise_dBm(ch.bandwidth)
         noise = thermal + ch.noise_figure_dB + ch.interference_dB
+        if ch.humidity_noise_coeff_dB != 0.0:
+            noise += ch.humidity_noise_coeff_dB * (ch._humidity.sample() / 100.0)
         for f, bw, power in ch.band_interference:
             half = (bw + ch.bandwidth) / 2.0
             if abs(ch.frequency_hz - f) <= half:

--- a/simulateur_lora_sfrd_4.0/tests/test_advanced_channel.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_advanced_channel.py
@@ -132,6 +132,19 @@ def test_temperature_dependent_noise():
     assert snr1 != snr2
 
 
+def test_humidity_dependent_noise():
+    random.seed(0)
+    adv = AdvancedChannel(
+        fading="",
+        shadowing_std=0,
+        humidity_std_percent=10.0,
+        humidity_noise_coeff_dB=1.0,
+    )
+    _, snr1 = adv.compute_rssi(14.0, 100.0)
+    _, snr2 = adv.compute_rssi(14.0, 100.0)
+    assert snr1 != snr2
+
+
 def test_pa_non_linearity():
     random.seed(0)
     adv = AdvancedChannel(

--- a/simulateur_lora_sfrd_4.0/tests/test_channel.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_channel.py
@@ -73,6 +73,18 @@ def test_temperature_variation_changes_snr():
     assert snr1 != snr2
 
 
+def test_humidity_variation_changes_snr():
+    random.seed(0)
+    ch = Channel(
+        shadowing_std=0,
+        humidity_std_percent=10.0,
+        humidity_noise_coeff_dB=1.0,
+    )
+    _, snr1 = ch.compute_rssi(14.0, 100.0)
+    _, snr2 = ch.compute_rssi(14.0, 100.0)
+    assert snr1 != snr2
+
+
 def test_pa_non_linearity_channel():
     random.seed(0)
     ch = Channel(shadowing_std=0, pa_non_linearity_std_dB=1.0)


### PR DESCRIPTION
## Summary
- extend `Channel` and `AdvancedChannel` to support humidity-dependent noise
- update OMNeT++ PHY helper for humidity
- document the new parameters in README
- add regression tests for humidity noise

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f68cec9e88331ae018eea8794a7ed