### PR TITLE
Add beacon loss and class C improvements

### DIFF
--- a/simulateur_lora_sfrd_4.0/CHANGELOG.md
+++ b/simulateur_lora_sfrd_4.0/CHANGELOG.md
@@ -4,3 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [0.1.0] - 2023-06-19
 - Initial public release of the Python based LoRa network simulator.
+
+## [0.1.1] - 2025-07-22
+- Enhanced LoRaWAN Class B/C management.
+  - Beacon loss probability and clock drift can now be configured per node.
+  - Scheduled downlinks for Class C nodes are delivered at the exact time for
+    more realistic continuous listening.

--- a/simulateur_lora_sfrd_4.0/README.md
+++ b/simulateur_lora_sfrd_4.0/README.md
@@ -29,8 +29,8 @@ This repository contains a lightweight LoRa network simulator implemented in Pyt
   (FLoRa energy profile)
 - Regional channel plans for EU868, US915, AU915 and Asian bands
 - Customizable energy profiles with a simple registry
-- Beacon loss and clock drift simulation for Class B nodes
-- Energy-aware quasi-continuous listening for Class C nodes
+- Beacon loss probability and clock drift simulation for Class B nodes
+- Realistic continuous listening for Class C nodes with precise downlink timing
 
 ## Quick start
 

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/simulator.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/simulator.py
@@ -237,7 +237,7 @@ class Simulator:
 
         # Compatibilité : premier canal par défaut
         self.channel = self.multichannel.channels[0]
-        self.network_server = NetworkServer()
+        self.network_server = NetworkServer(simulator=self)
         self.network_server.beacon_interval = self.beacon_interval
         self.network_server.beacon_drift = self.beacon_drift
         self.network_server.ping_slot_interval = self.ping_slot_interval


### PR DESCRIPTION
## Summary
- allow `NetworkServer` to schedule events via simulator
- add precise downlink scheduling for Class C nodes
- pass simulator to `NetworkServer`
- document improved Class B/C support

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f68ec3ef0833196218fe178aebc58