### PR TITLE
Improve LoRaWAN security validation

### DIFF
--- a/simulateur_lora_sfrd_4.0/README.md
+++ b/simulateur_lora_sfrd_4.0/README.md
@@ -316,7 +316,8 @@ This project is licensed under the [MIT License](LICENSE).
   imperfections found in real devices.
 - By default mobility relies on Bezier paths; an optional RandomWaypoint model
   can use terrain maps to handle obstacles.
-- Basic LoRaWAN security (AES encryption and MIC) is enabled by default but join
-  server handling and encryption validation are kept minimal.
+- Basic LoRaWAN security is enabled. A dedicated join server validates
+  JoinRequests and derives session keys, and all LoRaWAN frames are checked for
+  a valid MIC before decryption.
 
 Contributions are welcome to improve these areas or add missing features.

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/node.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/node.py
@@ -467,15 +467,11 @@ class Node:
         self.downlink_pending = max(0, self.downlink_pending - 1)
         payload = frame.payload
         if self.security_enabled and getattr(frame, "encrypted_payload", None) is not None:
-            if compute_mic(self.nwkskey, self.devaddr, frame.fcnt, 1, frame.encrypted_payload) != frame.mic:
+            from .lorawan import validate_frame
+
+            if not validate_frame(frame, self.nwkskey, self.appskey, self.devaddr, 1):
                 return
-            payload = encrypt_payload(
-                self.appskey,
-                self.devaddr,
-                frame.fcnt,
-                1,
-                frame.encrypted_payload,
-            )
+            payload = frame.payload
 
         if isinstance(payload, bytes):
             if len(payload) >= 5 and payload[0] == 0x03:

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/server.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/server.py
@@ -209,24 +209,16 @@ class NetworkServer:
             return
 
         if node and frame is not None and node.security_enabled:
-            from .lorawan import encrypt_payload, compute_mic, LoRaWANFrame
+            from .lorawan import validate_frame, LoRaWANFrame
 
-            if isinstance(frame, LoRaWANFrame) and frame.encrypted_payload is not None:
-                if compute_mic(
-                    node.nwkskey,
-                    node.devaddr,
-                    frame.fcnt,
-                    0,
-                    frame.encrypted_payload,
-                ) != frame.mic:
-                    return
-                frame.payload = encrypt_payload(
-                    node.appskey,
-                    node.devaddr,
-                    frame.fcnt,
-                    0,
-                    frame.encrypted_payload,
-                )
+            if isinstance(frame, LoRaWANFrame) and not validate_frame(
+                frame,
+                node.nwkskey,
+                node.appskey,
+                node.devaddr,
+                0,
+            ):
+                return
 
         if node and not getattr(node, "activated", True):
             self._activate(node, gateway=gw)


### PR DESCRIPTION
## Summary
- check MIC/decoding of every LoRaWAN frame via `validate_frame`
- update README to describe join server and systematic security validation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f68f9eb7083318ee983cafa3aa3a2