### PR TITLE
Add live FLoRa comparison in dashboard

### DIFF
--- a/simulateur_lora_sfrd_4.0/README.md
+++ b/simulateur_lora_sfrd_4.0/README.md
@@ -52,6 +52,8 @@ The dashboard now exposes a **Seed** input. Set the same value on
 subsequent runs to keep the node placement identical.
 Enable **Manual positions** to override node or gateway coordinates. Each line
 should follow `node,id=3,x=120,y=40` or `gw,id=1,x=10,y=80`.
+Load a reference export in **CSV FLoRa** to display live comparisons between
+FLoRa and the running simulation.
 
 # Run a simulation
 ```bash


### PR DESCRIPTION
## Summary
- enable loading a FLoRa CSV inside the dashboard
- show a real-time FLoRa ↔ SFRD metrics table during simulation
- document new `CSV FLoRa` input in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f692ee5ec8331a4d1d66a89dd9fa1