### PR TITLE
Extend Omnet PHY model

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/README.md
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/README.md
@@ -175,6 +175,9 @@ réception :
 - `pa_non_linearity_dB` / `pa_non_linearity_std_dB` : modélisent la
   non‑linéarité de l'amplificateur de puissance.
 - `phase_noise_std_dB` : bruit de phase ajouté au SNR.
+- `oscillator_leakage_dB` / `oscillator_leakage_std_dB` : fuite
+  d'oscillateur ajoutée au bruit.
+- `rx_fault_std_dB` : défauts de réception aléatoires pénalisant le SNR.
 - `band_interference` : liste de brouilleurs sélectifs sous la forme
   `(freq, bw, dB)` appliqués au calcul du bruit.
 - `environment` : preset rapide pour le modèle de propagation

--- a/simulateur_lora_sfrd_4.0/tests/test_cross_validate.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_cross_validate.py
@@ -16,3 +16,18 @@ def test_cross_validate_multi():
     params, err = cross_validate([csv1, csv2], runs=1, path_loss_values=(2.7,), shadowing_values=(6.0,), seed=0)
     assert params is not None
     assert err >= 0.0
+
+
+def test_cross_validate_multi_advanced():
+    csv1 = Path(__file__).parent / "data" / "flora_sample.csv"
+    csv2 = Path(__file__).parent / "data" / "flora_full.csv"
+    params, err = cross_validate(
+        [csv1, csv2],
+        runs=1,
+        path_loss_values=(2.7,),
+        shadowing_values=(6.0,),
+        seed=0,
+        advanced=True,
+    )
+    assert params is not None
+    assert err >= 0.0

--- a/simulateur_lora_sfrd_4.0/tests/test_omnet_phy.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_omnet_phy.py
@@ -72,7 +72,21 @@ def test_device_specific_features_in_phy():
         temperature_std_K=20.0,
         pa_non_linearity_std_dB=1.0,
         phase_noise_std_dB=2.0,
+        oscillator_leakage_dB=1.0,
+        oscillator_leakage_std_dB=0.5,
+        rx_fault_std_dB=1.0,
     )
     r1, _ = ch.omnet_phy.compute_rssi(14.0, 100.0)
     r2, _ = ch.omnet_phy.compute_rssi(14.0, 100.0)
     assert r1 != r2
+
+
+def test_oscillator_leakage_affects_noise():
+    ch = Channel(shadowing_std=0, phy_model="omnet")
+    base_noise = ch.omnet_phy.noise_floor()
+    ch.omnet_phy = OmnetPHY(
+        ch,
+        oscillator_leakage_dB=5.0,
+    )
+    leak_noise = ch.omnet_phy.noise_floor()
+    assert leak_noise > base_noise


### PR DESCRIPTION
## Summary
- extend `OmnetPHY` with oscillator leakage and receiver faults
- document new parameters in README
- test new OmnetPHY options
- check advanced calibration routine

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f783c41f883319e24e01888f4c174