### PR TITLE
Update docs about class B and C features

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/README.md
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/README.md
@@ -292,9 +292,9 @@ This Python rewrite preserves most concepts of the OMNeT++ model but intentional
 - customizable energy profiles
 - ADR commands (`LinkADRReq/Ans`, `ADRACKReq`, channel mask, `NbTrans`)
 - OTAA join procedure and scheduled downlink queue
+- complete management of LoRaWAN classes B and C with optional beacon loss
+  probability and clock drift
 
-**Partially implemented**
-- preliminary support for classes B and C
 
 **Omitted**
 - OMNeT++ GUI and detailed physical layer simulation
@@ -393,8 +393,6 @@ encore de maturité :
 
 - La couche physique est simplifiée et n'imite pas parfaitement les comportements
   réels des modems LoRa.
-- Les classes B et C sont gérées de manière basique : les pertes de beacon ou
-  la dérive temporelle ne sont pas simulées.
 - La mobilité par défaut s'appuie sur des trajets de Bézier. Un modèle RandomWaypoint peut exploiter une carte de terrain pour éviter les obstacles. Un module de navigation peut désormais planifier des chemins à partir d'une carte d'obstacles.
 - La sécurité LoRaWAN (chiffrement AES/MIC) est activée par défaut mais les
   serveurs de jointure et la validation du chiffrement restent simplifiés.


### PR DESCRIPTION
## Summary
- document beacon loss and clock drift for LoRaWAN class B
- remove outdated statement about incomplete class B/C support

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f7853d9c08331b299e2b50fec91f9