### PR TITLE
Add GPX mobility support

### DIFF
--- a/simulateur_lora_sfrd_4.0/README.md
+++ b/simulateur_lora_sfrd_4.0/README.md
@@ -6,8 +6,8 @@ This repository contains a lightweight LoRa network simulator implemented in Pyt
 - Duty cycle enforcement to mimic real LoRa constraints
 - Optional node mobility with Bezier interpolation or terrain-aware random
   waypoint movement, plus path-based navigation avoiding obstacles. Additional
-  models include Gauss–Markov, GPS trace playback and terrain following with
-  3D obstacle maps.
+  models include Gauss–Markov, GPS trace playback (CSV or GPX) and terrain
+  following with 3D obstacle maps.
 - Multi-channel radio support
 - Advanced channel model with loss and noise parameters
 - Optional multipath fading with synchronised paths and external interference modeling

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/gps_mobility.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/gps_mobility.py
@@ -1,28 +1,58 @@
 import csv
 from pathlib import Path
 from typing import Iterable, Sequence
+from xml.etree import ElementTree
+from datetime import datetime
 
 
 class GPSTraceMobility:
     """Mobility based on time-stamped GPS traces."""
 
     def __init__(self, trace: str | Iterable[Sequence[float]], loop: bool = True) -> None:
-        if isinstance(trace, str) or isinstance(trace, Path):
+        if isinstance(trace, (str, Path)):
             rows = []
-            with open(trace, "r", newline="") as f:
-                for row in csv.reader(f):
-                    if not row:
-                        continue
-                    values = [float(v) for v in row]
-                    if len(values) == 3:
-                        t, x, y = values
-                        z = 0.0
+            path = Path(trace)
+            if path.suffix.lower() == ".gpx":
+                root = ElementTree.parse(path).getroot()
+                if "}" in root.tag:
+                    ns = {"ns": root.tag.split("}")[0].strip("{")}
+                    search = ".//ns:trkpt"
+                else:
+                    ns = {}
+                    search = ".//trkpt"
+                prefix = "ns:" if ns else ""
+                for i, pt in enumerate(root.findall(search, ns)):
+                    lat = float(pt.attrib.get("lat", 0.0))
+                    lon = float(pt.attrib.get("lon", 0.0))
+                    ele = pt.find(f"{prefix}ele", ns)
+                    alt = float(ele.text) if ele is not None else 0.0
+                    time_el = pt.find(f"{prefix}time", ns)
+                    if time_el is not None:
+                        try:
+                            t = datetime.fromisoformat(time_el.text.replace("Z", "+00:00")).timestamp()
+                        except Exception:
+                            t = float(i)
                     else:
-                        t, x, y, z = (values + [0.0])[:4]
-                    rows.append((t, x, y, z))
+                        t = float(i)
+                    rows.append((t, lon, lat, alt))
+            else:
+                with open(path, "r", newline="") as f:
+                    for row in csv.reader(f):
+                        if not row:
+                            continue
+                        values = [float(v) for v in row]
+                        if len(values) == 3:
+                            t, x, y = values
+                            z = 0.0
+                        else:
+                            t, x, y, z = (values + [0.0])[:4]
+                        rows.append((t, x, y, z))
         else:
             rows = [tuple(map(float, r + (0.0,) * (4 - len(r)))) for r in trace]
         rows.sort(key=lambda r: r[0])
+        if rows and rows[0][0] > 1e6:
+            base = rows[0][0]
+            rows = [(t - base, x, y, z) for (t, x, y, z) in rows]
         if len(rows) < 2:
             raise ValueError("Trace must contain at least two points")
         self.trace = rows

--- a/simulateur_lora_sfrd_4.0/tests/test_gps_gpx.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_gps_gpx.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from VERSION_4.launcher.node import Node  # noqa: E402
+from VERSION_4.launcher.channel import Channel  # noqa: E402
+from VERSION_4.launcher.gps_mobility import GPSTraceMobility  # noqa: E402
+
+
+def test_gpx_trace(tmp_path):
+    gpx_file = tmp_path / "trace.gpx"
+    gpx_file.write_text(
+        """<gpx version='1.1' creator='test'>\n"
+        "<trk><trkseg>\n"
+        "<trkpt lat='0' lon='0'><time>2020-01-01T00:00:00Z</time></trkpt>\n"
+        "<trkpt lat='10' lon='20'><time>2020-01-01T00:10:00Z</time></trkpt>\n"
+        "</trkseg></trk></gpx>\n"""
+    )
+    mob = GPSTraceMobility(str(gpx_file))
+    node = Node(1, 0.0, 0.0, 7, 14.0, channel=Channel())
+    mob.assign(node)
+    mob.move(node, 300.0)
+    assert node.x == pytest.approx(10.0)
+    assert node.y == pytest.approx(5.0)


### PR DESCRIPTION
## Summary
- extend GPS trace mobility to read GPX files
- normalise absolute timestamps
- document GPX support in README
- add regression test for GPX mobility

## Testing
- `pytest -k gps -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f788320e083318f4e4ac7f6b097e1