### PR TITLE
Fix unused fading and noise parameters

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/run.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/run.py
@@ -79,9 +79,17 @@ def simulate(nodes, gateways, mode, interval, steps, channels=1,
                     energy_consumed += nb_tx * 1.0
                     if nb_tx == 1:
                         n = nodes_on_ch[0]
-                        delivered += 1
-                        delays.append(t - pending[n])
-                        del pending[n]
+                        success = True
+                        if fine_fading_std > 0.0 and random.gauss(0.0, fine_fading_std) < -3.0:
+                            success = False
+                        if noise_std > 0.0 and random.gauss(0.0, noise_std) > 3.0:
+                            success = False
+                        if success:
+                            delivered += 1
+                            delays.append(t - pending[n])
+                            del pending[n]
+                        else:
+                            collisions += 1
                     else:
                         collisions += nb_tx - 1
                         winner = random.choice(nodes_on_ch)


### PR DESCRIPTION
## Summary
- factor in `fine_fading_std` and `noise_std` parameters to the simple LoRa simulation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687f835bdd288331a72d3a5ca1d7292a