### PR TITLE
Fix metrics and typing issues

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/compare_flora.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/compare_flora.py
@@ -145,6 +145,7 @@ def load_flora_metrics(path: str | Path) -> dict[str, Any]:
     throughput = (
         float(df["throughput_bps"].mean()) if "throughput_bps" in df.columns else 0.0
     )
+    avg_delay = float(df["avg_delay_s"].mean()) if "avg_delay_s" in df.columns else 0.0
     if "energy_J" in df.columns:
         energy = float(df["energy_J"].mean())
     elif "energy" in df.columns:

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/join_server.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/join_server.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - used for type hints only
+    from .lorawan import JoinAccept, JoinRequest, RejoinRequest
 
 
 @dataclass

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/server.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/server.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING
 from .downlink_scheduler import DownlinkScheduler
 from .join_server import JoinServer  # re-export
 
+__all__ = ["NetworkServer", "JoinServer"]
+
 if TYPE_CHECKING:  # pragma: no cover - for type checking only
     from .lorawan import LoRaWANFrame, JoinAccept
 

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/simulator.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/simulator.py
@@ -1,7 +1,6 @@
 import heapq
 import logging
 import random
-import math
 from pathlib import Path
 from dataclasses import dataclass
 from enum import IntEnum


### PR DESCRIPTION
## Summary
- fix `load_flora_metrics` missing `avg_delay_s`
- add typing imports for `JoinServer`
- mark `JoinServer` for export from `server`
- remove unused import in `simulator`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687f8363c7c08331aef466f787bd1511