### PR TITLE
Ajout filtrage RF et scenarios validation

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/README.md
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/README.md
@@ -251,6 +251,10 @@ désormais une corrélation temporelle pour reproduire le comportement de
 FLoRa et un bruit variable peut être ajouté via ``variable_noise_std``.
 Une carte ``obstacle_height_map`` peut bloquer complètement un lien en
 fonction de l'altitude parcourue.
+Il est désormais possible de modéliser la sélectivité du filtre RF grâce aux
+paramètres ``frontend_filter_order`` et ``frontend_filter_bw``. Une valeur non
+nulle applique une atténuation dépendante du décalage fréquentiel, permettant de
+reproduire les effets observés dans OMNeT++.
 
 Le tableau de bord propose désormais un bouton **Mode FLoRa complet**. Quand il
 est activé, `detection_threshold_dBm` est automatiquement fixé à `-110` dBm et

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/advanced_channel.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/advanced_channel.py
@@ -87,6 +87,8 @@ class AdvancedChannel:
         humidity_std_percent: float = 0.0,
         humidity_noise_coeff_dB: float = 0.0,
         phase_noise_std_dB: float = 0.0,
+        frontend_filter_order: int = 0,
+        frontend_filter_bw: float | None = None,
         obstacle_map: list[list[float]] | None = None,
         map_area_size: float | None = None,
         obstacle_height_map: list[list[float]] | None = None,
@@ -144,6 +146,8 @@ class AdvancedChannel:
             d'humidité pour moduler le bruit (dB).
         :param phase_noise_std_dB: Bruit de phase appliqué au SNR (écart-type en
             dB).
+        :param frontend_filter_order: Ordre du filtre passe-bande simulé.
+        :param frontend_filter_bw: Largeur de bande du filtre (Hz).
         :param multipath_paths: Nombre de trajets multipath à simuler.
         :param indoor_n_floors: Nombre d'étages à traverser pour le modèle
             ``itu_indoor``.
@@ -174,6 +178,8 @@ class AdvancedChannel:
             humidity_percent=humidity_percent,
             humidity_std_percent=humidity_std_percent,
             humidity_noise_coeff_dB=humidity_noise_coeff_dB,
+            frontend_filter_order=frontend_filter_order,
+            frontend_filter_bw=frontend_filter_bw,
             **kwargs,
         )
         self.base_station_height = base_station_height

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/omnet_phy.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/omnet_phy.py
@@ -149,6 +149,7 @@ class OmnetPHY:
             rssi += random.gauss(0.0, ch.time_variation_std)
         rssi += self.model.fine_fading()
         rssi += ch.rssi_offset_dB
+        rssi -= ch._filter_attenuation_db(freq_offset_hz)
 
         snr = rssi - self.noise_floor() + ch.snr_offset_dB
         penalty = self._alignment_penalty_db(freq_offset_hz, sync_offset_s, sf)

--- a/simulateur_lora_sfrd_4.0/examples/hardware_validation.py
+++ b/simulateur_lora_sfrd_4.0/examples/hardware_validation.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Compare l'impact d'un filtre RF et d'une synchronisation imparfaite."""
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from VERSION_4.launcher.channel import Channel  # noqa: E402
+
+
+def main() -> None:
+    base = Channel(shadowing_std=0)
+    filt = Channel(
+        shadowing_std=0,
+        frontend_filter_order=2,
+        frontend_filter_bw=100e3,
+        frequency_offset_hz=40e3,
+    )
+    r1, s1 = base.compute_rssi(14.0, 100.0)
+    r2, s2 = filt.compute_rssi(14.0, 100.0)
+    print("Canal idéal : RSSI={:.2f} dBm SNR={:.2f} dB".format(r1, s1))
+    print(
+        "Avec filtre et désalignement : RSSI={:.2f} dBm SNR={:.2f} dB".format(
+            r2, s2
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/simulateur_lora_sfrd_4.0/tests/test_channel.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_channel.py
@@ -134,3 +134,16 @@ def test_variable_noise_changes_rssi():
     _, s1 = ch.compute_rssi(14.0, 100.0)
     _, s2 = ch.compute_rssi(14.0, 100.0)
     assert s1 != s2
+
+
+def test_frontend_filter_reduces_rssi():
+    base = Channel(shadowing_std=0)
+    filt = Channel(
+        shadowing_std=0,
+        frontend_filter_order=2,
+        frontend_filter_bw=100e3,
+        frequency_offset_hz=40e3,
+    )
+    r_base, _ = base.compute_rssi(14.0, 100.0)
+    r_filt, _ = filt.compute_rssi(14.0, 100.0)
+    assert r_filt < r_base


### PR DESCRIPTION
## Summary
- extend `Channel` with `frontend_filter_order` and `frontend_filter_bw`
- apply filter attenuation in `Channel` and `OmnetPHY`
- expose parameters through `AdvancedChannel`
- document filter options in README
- add comparative example `hardware_validation.py`
- test new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ffa2126208331943e7998368f5c63