### PR TITLE
Add 3D mobility and obstacle awareness

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/README.md
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/README.md
@@ -98,6 +98,10 @@ des trajectoires lissées par interpolation de Bézier. La vitesse des nœuds es
 tirée aléatoirement dans la plage spécifiée (par défaut 2 à 10 m/s) et peut être
 modifiée via le paramètre `mobility_speed` du `Simulator`. Les mouvements sont
 donc continus et sans téléportation.
+Un modèle `PathMobility` permet également de suivre des chemins définis sur une
+grille en évitant les obstacles et peut prendre en compte un relief ainsi que
+des hauteurs de bâtiments. L'altitude du nœud est alors mise à jour à chaque
+déplacement pour un calcul radio plus réaliste.
 Deux champs « Vitesse min » et « Vitesse max » sont disponibles dans le
 `dashboard` pour définir cette plage avant de lancer la simulation.
 

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/gateway.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/gateway.py
@@ -5,7 +5,8 @@ logger = logging.getLogger(__name__)
 
 class Gateway:
     """Représente une passerelle LoRa recevant les paquets des nœuds."""
-    def __init__(self, gateway_id: int, x: float, y: float):
+
+    def __init__(self, gateway_id: int, x: float, y: float, altitude: float = 0.0):
         """
         Initialise une passerelle LoRa.
         :param gateway_id: Identifiant de la passerelle.
@@ -15,6 +16,7 @@ class Gateway:
         self.id = gateway_id
         self.x = x
         self.y = y
+        self.altitude = altitude
         # Transmissions en cours indexées par (sf, frequency)
         self.active_map: dict[tuple[int, float], list[dict]] = {}
         # Mapping event_id -> (key, dict) for quick removal

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/node.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/node.py
@@ -227,15 +227,12 @@ class Node:
         return max(0.0, self.battery_remaining_j / self.battery_capacity_j)
 
     def distance_to(self, other) -> float:
-        """
-        Calcule la distance euclidienne (mètres) entre ce nœud et un autre objet possédant
-        des attributs x et y (par exemple une passerelle).
-
-        :param other: Objet avec attributs x et y.
-        :return: Distance euclidienne (mètres).
-        """
+        """Calcule la distance 2D ou 3D jusqu'à ``other`` si possible."""
         dx = self.x - other.x
         dy = self.y - other.y
+        if hasattr(other, "altitude"):
+            dz = getattr(self, "altitude", 0.0) - getattr(other, "altitude", 0.0)
+            return math.sqrt(dx * dx + dy * dy + dz * dz)
         return math.hypot(dx, dy)
 
     # ------------------------------------------------------------------

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/simulator.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/simulator.py
@@ -479,8 +479,8 @@ class Simulator:
                     "sync_offset_s": getattr(node, "current_sync_offset", 0.0),
                 }
                 if hasattr(node.channel, "_obstacle_loss"):
-                    kwargs["tx_pos"] = (node.x, node.y)
-                    kwargs["rx_pos"] = (gw.x, gw.y)
+                    kwargs["tx_pos"] = (node.x, node.y, getattr(node, "altitude", 0.0))
+                    kwargs["rx_pos"] = (gw.x, gw.y, getattr(gw, "altitude", 0.0))
                 rssi, snr = node.channel.compute_rssi(
                     tx_power,
                     distance,
@@ -699,8 +699,8 @@ class Simulator:
                 distance = node.distance_to(gw)
                 kwargs = {"freq_offset_hz": 0.0, "sync_offset_s": 0.0}
                 if hasattr(node.channel, "_obstacle_loss"):
-                    kwargs["tx_pos"] = (gw.x, gw.y)
-                    kwargs["rx_pos"] = (node.x, node.y)
+                    kwargs["tx_pos"] = (gw.x, gw.y, getattr(gw, "altitude", 0.0))
+                    kwargs["rx_pos"] = (node.x, node.y, getattr(node, "altitude", 0.0))
                 rssi, snr = node.channel.compute_rssi(
                     node.tx_power,
                     distance,
@@ -797,8 +797,8 @@ class Simulator:
                     sf = DR_TO_SF.get(node.ping_slot_dr, node.sf)
                 kwargs = {"freq_offset_hz": 0.0, "sync_offset_s": 0.0}
                 if hasattr(node.channel, "_obstacle_loss"):
-                    kwargs["tx_pos"] = (gw.x, gw.y)
-                    kwargs["rx_pos"] = (node.x, node.y)
+                    kwargs["tx_pos"] = (gw.x, gw.y, getattr(gw, "altitude", 0.0))
+                    kwargs["rx_pos"] = (node.x, node.y, getattr(node, "altitude", 0.0))
                 rssi, snr = node.channel.compute_rssi(
                     node.tx_power,
                     distance,

--- a/simulateur_lora_sfrd_4.0/tests/test_advanced_channel.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_advanced_channel.py
@@ -111,6 +111,13 @@ def test_obstacle_height_blocks_link():
     assert r == -float("inf")
 
 
+def test_3d_compute_rssi_uses_altitude():
+    adv = AdvancedChannel(propagation_model="3d", fading="", shadowing_std=0)
+    r1, _ = adv.compute_rssi(14.0, 100.0, tx_pos=(0.0, 0.0, 0.0), rx_pos=(0.0, 100.0, 0.0))
+    r2, _ = adv.compute_rssi(14.0, 100.0, tx_pos=(0.0, 0.0, 10.0), rx_pos=(0.0, 100.0, 0.0))
+    assert r2 < r1
+
+
 def test_device_specific_offset():
     random.seed(0)
     adv = AdvancedChannel(

--- a/simulateur_lora_sfrd_4.0/tests/test_node_defaults.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_node_defaults.py
@@ -5,6 +5,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 from VERSION_4.launcher.node import Node  # noqa: E402
+from VERSION_4.launcher.gateway import Gateway  # noqa: E402
 
 
 def test_node_default_channel():
@@ -13,3 +14,10 @@ def test_node_default_channel():
     assert node.channel is not None
     # The channel should provide airtime calculation without error
     assert node.channel.airtime(7) > 0
+
+
+def test_distance_to_uses_altitude():
+    node = Node(1, 0.0, 0.0, 7, 14.0)
+    gw = Gateway(1, 0.0, 0.0, altitude=10.0)
+    node.altitude = 0.0
+    assert node.distance_to(gw) == 10.0

--- a/simulateur_lora_sfrd_4.0/tests/test_path_mobility.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_path_mobility.py
@@ -33,3 +33,14 @@ def test_simulator_uses_path_mobility(tmp_path):
                     path_map=str(path_file))
     assert isinstance(sim.mobility_model, PathMobility)
 
+
+def test_path_mobility_sets_altitude():
+    grid = [[0.0, 0.0], [0.0, 0.0]]
+    elevation = [[0.0, 2.0], [4.0, 6.0]]
+    mob = PathMobility(area_size=100.0, path_map=grid, elevation=elevation)
+    node = Node(1, 60.0, 60.0, 7, 14.0, channel=Channel())
+    mob.assign(node)
+    start_alt = node.altitude
+    mob.move(node, 20.0)
+    assert node.altitude != start_alt
+


### PR DESCRIPTION
## Summary
- support altitude in `Node.distance_to` and gateways
- include altitude for path loss and obstruction calculations
- extend `PathMobility` with elevation and building height maps
- update simulator to pass altitude to channel
- document new mobility options
- add tests for altitude handling and 3D propagation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ffa43f04483319204e2e45f72e422