### PR TITLE
Ajout jitter horloge et distorsion PA

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/README.md
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/README.md
@@ -176,6 +176,7 @@ réception :
 - `variable_noise_std` : bruit thermique lentement variable (dB).
 - `freq_drift_std_hz` et `clock_drift_std_s` : dérives de fréquence et
   d'horloge corrélées utilisées pour le calcul du SNR.
+- `clock_jitter_std_s` : gigue d'horloge ajoutée à chaque calcul.
 - `temperature_std_K` : variation de température pour le calcul du bruit.
 - `humidity_percent` et `humidity_noise_coeff_dB` : ajoutent un bruit
   supplémentaire proportionnel à l'humidité relative. La variation temporelle
@@ -184,6 +185,7 @@ réception :
   non‑linéarité de l'amplificateur de puissance.
 - `pa_non_linearity_curve` : triplet de coefficients polynomiaux pour
   définir une non‑linéarité personnalisée.
+- `pa_distortion_std_dB` : variation aléatoire due aux imperfections du PA.
 - `phase_noise_std_dB` : bruit de phase ajouté au SNR.
 - `oscillator_leakage_dB` / `oscillator_leakage_std_dB` : fuite
   d'oscillateur ajoutée au bruit.

--- a/simulateur_lora_sfrd_4.0/tests/test_advanced_channel.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_advanced_channel.py
@@ -202,3 +202,27 @@ def test_interference_penalty_inf():
     symbol_time = (2 ** 7) / adv.base.bandwidth
     penalty = adv._interference_penalty_db(freq_offset, symbol_time, 7)
     assert penalty == float("inf")
+
+
+def test_clock_jitter_variation():
+    random.seed(0)
+    adv = AdvancedChannel(
+        fading="",
+        shadowing_std=0,
+        clock_jitter_std_s=0.0005,
+    )
+    _, snr1 = adv.compute_rssi(14.0, 100.0)
+    _, snr2 = adv.compute_rssi(14.0, 100.0)
+    assert snr1 != snr2
+
+
+def test_pa_distortion_affects_rssi():
+    random.seed(0)
+    adv = AdvancedChannel(
+        fading="",
+        shadowing_std=0,
+        pa_distortion_std_dB=1.0,
+    )
+    r1, _ = adv.compute_rssi(14.0, 100.0)
+    r2, _ = adv.compute_rssi(14.0, 100.0)
+    assert r1 != r2


### PR DESCRIPTION
## Summary
- expose de nouveaux paramètres `clock_jitter_std_s` et `pa_distortion_std_dB`
- prise en compte dans `AdvancedChannel`
- docs mises à jour
- tests unitaires pour ces options

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688017fbe7f88331ad81364e74322bc3