### PR TITLE
Implement dynamic obstacles and trace mobility

### DIFF
--- a/simulateur_lora_sfrd_4.0/README.md
+++ b/simulateur_lora_sfrd_4.0/README.md
@@ -94,6 +94,17 @@ sim = Simulator(num_nodes=20, num_gateways=3, area_size=2000.0, mobility=True,
 sim.run(1000)
 ```
 
+#### Chargement de traces GPS
+
+```python
+from launcher import Simulator, MultiGPSTraceMobility
+
+mob = MultiGPSTraceMobility("traces/")
+sim = Simulator(num_nodes=2, num_gateways=1, area_size=100.0, mobility=True)
+sim.mobility_model = mob
+sim.run(100)
+```
+
 ### Exemple de scénario FLoRa
 
 ```bash

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/__init__.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/__init__.py
@@ -11,7 +11,7 @@ from .smooth_mobility import SmoothMobility
 from .mobility import RandomWaypoint
 from .path_mobility import PathMobility
 from .gauss_markov import GaussMarkov
-from .gps_mobility import GPSTraceMobility
+from .gps_mobility import GPSTraceMobility, MultiGPSTraceMobility
 from .map_loader import load_map
 from .lorawan import LoRaWANFrame, compute_rx1, compute_rx2
 from .downlink_scheduler import DownlinkScheduler
@@ -33,6 +33,7 @@ __all__ = [
     "PathMobility",
     "GaussMarkov",
     "GPSTraceMobility",
+    "MultiGPSTraceMobility",
     "load_map",
     "LoRaWANFrame",
     "compute_rx1",

--- a/simulateur_lora_sfrd_4.0/tests/test_gps_mobility.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_gps_mobility.py
@@ -7,7 +7,7 @@ sys.path.insert(0, str(ROOT))
 
 from VERSION_4.launcher.node import Node  # noqa: E402
 from VERSION_4.launcher.channel import Channel  # noqa: E402
-from VERSION_4.launcher.gps_mobility import GPSTraceMobility  # noqa: E402
+from VERSION_4.launcher.gps_mobility import GPSTraceMobility, MultiGPSTraceMobility  # noqa: E402
 
 
 def test_gps_trace_interpolation(tmp_path):
@@ -19,3 +19,19 @@ def test_gps_trace_interpolation(tmp_path):
     mob.move(node, 5.0)
     assert node.x == pytest.approx(5.0)
     assert node.y == pytest.approx(0.0)
+
+
+def test_multi_gps_trace(tmp_path):
+    traces = tmp_path / "traces"
+    traces.mkdir()
+    (traces / "t1.csv").write_text("0,0,0\n10,10,0\n")
+    (traces / "t2.csv").write_text("0,0,0\n10,0,10\n")
+    mob = MultiGPSTraceMobility(str(traces))
+    n1 = Node(1, 0.0, 0.0, 7, 14.0, channel=Channel())
+    n2 = Node(2, 0.0, 0.0, 7, 14.0, channel=Channel())
+    mob.assign(n1)
+    mob.assign(n2)
+    mob.move(n1, 5.0)
+    mob.move(n2, 5.0)
+    assert n1.x == pytest.approx(5.0)
+    assert n2.y == pytest.approx(5.0)

--- a/simulateur_lora_sfrd_4.0/tests/test_random_waypoint.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_random_waypoint.py
@@ -56,3 +56,16 @@ def test_random_waypoint_elevation_speed_up():
     node.last_move_time = 0.0
     mob.move(node, 1.0)
     assert node.x == pytest.approx(55.0)
+
+
+def test_random_waypoint_dynamic_obstacle():
+    obs = [{"x": 50.0, "y": 50.0, "radius": 5.0}]
+    mob = RandomWaypoint(area_size=100.0, min_speed=10.0, max_speed=10.0,
+                         dynamic_obstacles=obs)
+    node = Node(1, 45.0, 50.0, 7, 14.0, channel=Channel())
+    node.vx = 10.0
+    node.vy = 0.0
+    node.last_move_time = 0.0
+    mob.move(node, 1.0)
+    assert node.x < 50.0
+    assert node.vx < 0


### PR DESCRIPTION
## Summary
- support dynamic obstacles and topography in `RandomWaypoint`
- add `MultiGPSTraceMobility` to assign traces to multiple nodes
- export new class from package and document trace loading
- test dynamic obstacles and trace loader

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6880181618ac83319f5004ca3f8b9da6