### PR TITLE
Extend LoRaWAN features

### DIFF
--- a/simulateur_lora_sfrd_4.0/tests/test_lorawan.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_lorawan.py
@@ -15,6 +15,12 @@ from VERSION_4.launcher.lorawan import (  # noqa: E402
     ADRParamSetupReq,
     RejoinParamSetupReq,
     DeviceModeInd,
+    FragSessionSetupReq,
+    FragSessionSetupAns,
+    FragSessionDeleteReq,
+    FragSessionDeleteAns,
+    FragStatusReq,
+    FragStatusAns,
 )
 
 
@@ -126,6 +132,35 @@ def test_device_mode_ind_roundtrip():
     data = ind.to_bytes()
     parsed = DeviceModeInd.from_bytes(data)
     assert parsed == ind
+
+
+def test_frag_session_setup_roundtrip():
+    req = FragSessionSetupReq(1, 10, 50)
+    data = req.to_bytes()
+    parsed = FragSessionSetupReq.from_bytes(data)
+    assert parsed == req
+    ans = FragSessionSetupAns(1).to_bytes()
+    assert FragSessionSetupAns.from_bytes(ans) == FragSessionSetupAns(1)
+
+
+def test_frag_session_delete_roundtrip():
+    req = FragSessionDeleteReq(2)
+    data = req.to_bytes()
+    parsed = FragSessionDeleteReq.from_bytes(data)
+    assert parsed == req
+    ans = FragSessionDeleteAns().to_bytes()
+    assert FragSessionDeleteAns.from_bytes(ans) == FragSessionDeleteAns(0)
+
+
+def test_frag_status_roundtrip():
+    req = FragStatusReq(1)
+    data = req.to_bytes()
+    parsed = FragStatusReq.from_bytes(data)
+    assert parsed == req
+    ans = FragStatusAns(1, 0)
+    data2 = ans.to_bytes()
+    parsed2 = FragStatusAns.from_bytes(data2)
+    assert parsed2 == ans
 
 
 def test_ping_slot_channel_ans_roundtrip():

--- a/simulateur_lora_sfrd_4.0/tests/test_security_validation.py
+++ b/simulateur_lora_sfrd_4.0/tests/test_security_validation.py
@@ -8,6 +8,8 @@ from VERSION_4.launcher.lorawan import (  # noqa: E402
     LoRaWANFrame,
     encrypt_payload,
     compute_mic,
+    encrypt_multicast_payload,
+    compute_multicast_mic,
     validate_frame,
     validate_join_request,
     compute_join_mic,
@@ -53,3 +55,24 @@ def test_validate_frame_and_join_request():
 
     req.mic = b"\x00\x00\x00\x00"
     assert not validate_join_request(req, key)
+
+
+def test_multicast_encryption_helpers():
+    nwk = bytes(range(16))
+    app = bytes(range(16, 32))
+    mc_addr = 0x01020304
+    payload = b"group"
+
+    enc = encrypt_multicast_payload(app, mc_addr, 2, payload)
+    mic = compute_multicast_mic(nwk, mc_addr, 2, enc)
+    frame = LoRaWANFrame(
+        mhdr=0x60,
+        fctrl=0,
+        fcnt=2,
+        payload=b"",
+        confirmed=False,
+        mic=mic,
+        encrypted_payload=enc,
+    )
+    assert validate_frame(frame, nwk, app, mc_addr, 1)
+    assert frame.payload == payload


### PR DESCRIPTION
## Summary
- add LoRaWAN multicast encryption helpers
- implement basic fragmentation MAC commands
- update Node to support new MAC commands
- test coverage for new helpers and dataclasses

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688018656bec833182225a0ad0447f7c