### PR TITLE
Remove fine fading UI

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/dashboard.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/dashboard.py
@@ -1209,8 +1209,6 @@ controls = pn.WidgetBox(
     mobility_speed_max_input,
     flora_mode_toggle,
     detection_threshold_input,
-    fine_fading_input,
-    noise_std_input,
     min_interference_input,
     battery_capacity_input,
     payload_size_input,


### PR DESCRIPTION
## Summary
- hide Fine Fading and Variable Noise options from the dashboard

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68821a2f5b308331bea2dd1c19132b74