### PR TITLE
Enable degraded channel for ADR1

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/adr_standard_1.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/adr_standard_1.py
@@ -5,7 +5,7 @@ from . import server
 from .advanced_channel import AdvancedChannel
 
 
-def apply(sim: Simulator, *, degrade_channel: bool = False) -> None:
+def apply(sim: Simulator, *, degrade_channel: bool = True) -> None:
     """Configure ADR variant ``adr_standard_1`` (LoRaWAN defaults).
 
     Parameters
@@ -13,9 +13,9 @@ def apply(sim: Simulator, *, degrade_channel: bool = False) -> None:
     sim : Simulator
         Instance to modify in-place.
     degrade_channel : bool, optional
-        When ``True`` apply harsh propagation settings to drastically
-        reduce the Packet Delivery Ratio.  Only the ADR1 preset applies
-        these changes.
+        When ``True`` (default) apply additional propagation
+        impairments to reduce the Packet Delivery Ratio.  Only the ADR1
+        preset applies these changes.
     """
     Simulator.MARGIN_DB = 15.0
     server.MARGIN_DB = Simulator.MARGIN_DB
@@ -34,17 +34,17 @@ def apply(sim: Simulator, *, degrade_channel: bool = False) -> None:
     if degrade_channel:
         for ch in sim.multichannel.channels:
             base = ch.base if isinstance(ch, AdvancedChannel) else ch
-            # Apply even stronger constant interference
-            base.interference_dB = max(base.interference_dB, 13.5)
-            # Increase the fast fading variance a bit more
-            base.fast_fading_std = max(base.fast_fading_std, 7.0)
-            # Raise the extra path loss exponent slightly higher
-            base.path_loss_exp = max(base.path_loss_exp, 3.75)
-            # Detection threshold higher than nominal sensitivity
-            base.detection_threshold_dBm = max(base.detection_threshold_dBm, -89.0)
-            # Allow more pronounced slow noise variations
-            base.noise_floor_std = max(base.noise_floor_std, 2.75)
+            # Apply moderate constant interference
+            base.interference_dB = max(base.interference_dB, 7.0)
+            # Increase the fast fading variance
+            base.fast_fading_std = max(base.fast_fading_std, 3.0)
+            # Raise the extra path loss exponent slightly
+            base.path_loss_exp = max(base.path_loss_exp, 3.25)
+            # Detection threshold above nominal sensitivity
+            base.detection_threshold_dBm = max(base.detection_threshold_dBm, -95.0)
+            # Allow noticeable slow noise variations
+            base.noise_floor_std = max(base.noise_floor_std, 1.5)
             if isinstance(ch, AdvancedChannel):
                 ch.fading = "rayleigh"
-                ch.weather_loss_dB_per_km = max(ch.weather_loss_dB_per_km, 1.3)
-        sim.detection_threshold_dBm = -89.0
+                ch.weather_loss_dB_per_km = max(ch.weather_loss_dB_per_km, 0.7)
+        sim.detection_threshold_dBm = -95.0

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/dashboard.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/dashboard.py
@@ -504,7 +504,7 @@ def select_adr(module, name: str) -> None:
         adr3_button.button_type = "primary"
     if sim is not None:
         if module is adr_standard_1:
-            module.apply(sim, degrade_channel=False)
+            module.apply(sim, degrade_channel=True)
         else:
             module.apply(sim)
 
@@ -701,7 +701,7 @@ def setup_simulation(seed_offset: int = 0):
     # Appliquer le profil ADR sélectionné
     if selected_adr_module:
         if selected_adr_module is adr_standard_1:
-            selected_adr_module.apply(sim, degrade_channel=False)
+            selected_adr_module.apply(sim, degrade_channel=True)
         else:
             selected_adr_module.apply(sim)
 


### PR DESCRIPTION
## Summary
- activate channel degradation by default for ADR1 and reduce the strength of the impairments
- update dashboard to apply degradation when ADR1 is selected

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68821ec36138833197225edecf7d385d