### PR TITLE
Tweak ADR1 degradation and stabilize intervals

### DIFF
--- a/simulateur_lora_sfrd_4.0/VERSION_4/README.md
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/README.md
@@ -137,6 +137,8 @@ scénarios FLoRa. Voici la liste complète des options :
 - `packet_interval` : moyenne ou période fixe entre transmissions (s).
 - `interval_variation` : coefficient de jitter appliqué à l'intervalle
   exponentiel (0 par défaut pour coller au comportement FLoRa).
+- L'intervalle est tronqué à deux fois `packet_interval` pour éviter des
+  écarts trop importants d'une exécution à l'autre.
 - `packets_to_send` : nombre de paquets émis **par nœud** avant arrêt (0 = infini).
 - `adr_node` / `adr_server` : active l'ADR côté nœud ou serveur.
 - `duty_cycle` : quota d'émission appliqué à chaque nœud (`None` pour désactiver).

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/adr_standard_1.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/adr_standard_1.py
@@ -34,17 +34,17 @@ def apply(sim: Simulator, *, degrade_channel: bool = True) -> None:
     if degrade_channel:
         for ch in sim.multichannel.channels:
             base = ch.base if isinstance(ch, AdvancedChannel) else ch
-            # Apply constant interference but with slightly lower impact
-            base.interference_dB = max(base.interference_dB, 6.0)
-            # Increase the fast fading variance moderately
-            base.fast_fading_std = max(base.fast_fading_std, 3.0)
-            # Raise the extra path loss exponent a little less
-            base.path_loss_exp = max(base.path_loss_exp, 3.3)
-            # Detection threshold above nominal sensitivity
-            base.detection_threshold_dBm = max(base.detection_threshold_dBm, -94.0)
-            # Allow slow noise variations with reduced amplitude
-            base.noise_floor_std = max(base.noise_floor_std, 1.5)
+            # Apply slightly stronger constant interference
+            base.interference_dB = max(base.interference_dB, 6.5)
+            # Increase the fast fading variance a little more
+            base.fast_fading_std = max(base.fast_fading_std, 3.5)
+            # Raise the extra path loss exponent very slightly
+            base.path_loss_exp = max(base.path_loss_exp, 3.4)
+            # Detection threshold slightly above previous value
+            base.detection_threshold_dBm = max(base.detection_threshold_dBm, -93.5)
+            # Allow slow noise variations with a bit more amplitude
+            base.noise_floor_std = max(base.noise_floor_std, 1.7)
             if isinstance(ch, AdvancedChannel):
                 ch.fading = "rayleigh"
-                ch.weather_loss_dB_per_km = max(ch.weather_loss_dB_per_km, 0.8)
-        sim.detection_threshold_dBm = -94.0
+                ch.weather_loss_dB_per_km = max(ch.weather_loss_dB_per_km, 0.9)
+        sim.detection_threshold_dBm = -93.5

--- a/simulateur_lora_sfrd_4.0/VERSION_4/launcher/simulator.py
+++ b/simulateur_lora_sfrd_4.0/VERSION_4/launcher/simulator.py
@@ -378,6 +378,8 @@ class Simulator:
     def _sample_interval(self) -> float:
         """Retourne un délai tiré de la loi exponentielle avec jitter."""
         interval = random.expovariate(1.0 / self.packet_interval)
+        if interval > 2 * self.packet_interval:
+            interval = 2 * self.packet_interval
         if self.interval_variation > 0.0:
             low = max(0.0, 1.0 - self.interval_variation)
             high = 1.0 + self.interval_variation


### PR DESCRIPTION
## Summary
- slightly raise interference and fading in `adr_standard_1`
- clamp sampled interval to 2x mean to limit extreme values
- document the cap on exponential intervals

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6882270ff8548331890f07f0a033c129